### PR TITLE
[#2969] check for expunged target user on manage/logins

### DIFF
--- a/cgi-bin/DW/Controller/Manage/Logins.pm
+++ b/cgi-bin/DW/Controller/Manage/Logins.pm
@@ -39,6 +39,7 @@ sub login_handler {
     if ( $adminmode && $user ) {
         $u = LJ::load_user($user);
         return error_ml('error.username_notfound') unless $u;
+        return error_ml('error.purged.text') if $u->is_expunged;
         $user = undef if $rv->{remote}->equals($u);
     }
     else {


### PR DESCRIPTION
CODE TOUR: no-impact except for site admins

Currently, if you try to load /manage/logins for a user that has been deleted and purged, the page goes straight to querying the database about that user and crashes. This adds a sanity check at the top of the page that stops and displays an error message in that particular case.

Fixes #2969.
