### PR TITLE
usability tweaks for build-static.sh

### DIFF
--- a/bin/build-static.sh
+++ b/bin/build-static.sh
@@ -5,6 +5,20 @@
 # 'perldoc perlartistic' or 'perldoc perlgpl'.
 
 
+force="--force"
+
+while getopts ":n" opt; do
+    case ${opt} in
+        n )
+            force=""
+            ;;
+        \? )
+            echo "$0: illegal option -- $OPTARG" 1>&2
+            exit 1
+            ;;
+    esac
+done
+
 buildroot="$LJHOME/build/static"
 mkdir -p $buildroot
 rm /tmp/jcompress
@@ -26,10 +40,10 @@ if [ "$compass" != "" ]; then
     if [ $compass_version_ok ]; then
         echo "* Building SCSS..."
         cd $LJHOME
-        $compass compile -e production --force
+        $compass compile -e production $force
         if [ -d "$LJHOME/ext/dw-nonfree" ]; then
             cd $LJHOME/ext/dw-nonfree
-            $compass compile -e production --force
+            $compass compile -e production $force
         fi
     else
         echo "Compass version must be 1.0 or higher. Please upgrade."

--- a/bin/build-static.sh
+++ b/bin/build-static.sh
@@ -21,7 +21,10 @@ done
 
 buildroot="$LJHOME/build/static"
 mkdir -p $buildroot
-rm /tmp/jcompress
+
+if [[ -e /tmp/jcompress ]]; then
+    rm /tmp/jcompress
+fi
 
 compressor="$LJHOME/ext/yuicompressor/yuicompressor.jar"
 uncompressed_dir="/max"
@@ -120,8 +123,10 @@ do
     done
 
     # Now parallel execute
-    echo "Executing compression (takes a minute)..."
-    cat /tmp/jcompress | xargs -d "\n" -n 1 -P 4 -- bash -c
+    if [[ -e /tmp/jcompress ]]; then
+        echo "Executing compression (takes a minute)..."
+        cat /tmp/jcompress | xargs -d "\n" -n 1 -P 4 -- bash -c
+    fi
 done
 
 if [[ -n $compressor ]]; then


### PR DESCRIPTION
CODE TOUR: no-impact for end users, this is a shell script run by site admins

A couple of tweaks to build-static.sh:

1. If no compressor is installed, `/tmp/jcompress` never gets used, which was causing bogus script errors.
2. Allow devs to save time by passing a `-n` option to the script, to only recompile files with new changes, instead of forcing every SCSS file to recompile every time the script is invoked.
