### PR TITLE
/tools/tellafriend is using the wrong template

### DIFF
--- a/cgi-bin/DW/Controller/Tools.pm
+++ b/cgi-bin/DW/Controller/Tools.pm
@@ -569,7 +569,7 @@ sub tellafriend_handler {
         'display_msg_footer' => $display_msg_footer,
         'email_checkbox'     => $email_checkbox
     };
-    return DW::Template->render_template( 'tools/emailmanage.tt', $vars );
+    return DW::Template->render_template( 'tools/tellafriend.tt', $vars );
 }
 
 1;


### PR DESCRIPTION
CODE TOUR: show the correct page when visiting /tools/tellafriend

This page was recently converted away from BML, but an apparent copy-paste error is rendering the template for /tools/emailmanage instead.