### PR TITLE
[#2960] don't double-escape URL parameters in returnto

### DIFF
--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -3306,7 +3306,7 @@ sub control_strip {
         'search_html' => LJ::Widget::Search->render,
 
         # url of the rendered page, for the login/logout form to redirect back to
-        'returnto' => $euri,
+        'returnto' => $baseuri,
     };
 
     # Shortcuts for the two nested array refs that get repeatedly dereferenced later


### PR DESCRIPTION
The form.hidden function applies escaping, so pass the unescaped variable to the template.

CODE TOUR: This fixes a problem with sometimes failing to return to the current page when logging in or out from the control strip.

Fixes #2960.