### PR TITLE
add ext/dw-nonfree/htdocs/stc/css to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ src/proxy/proxy
 .sass-cache
 # Ignore compiled CSS
 htdocs/stc/css
+ext/dw-nonfree/htdocs/stc/css
 
 # Ignore test stuff
 t-theschwartz.sqlite


### PR DESCRIPTION
CODE TOUR: no-impact

After moving dw-nonfree into the ext/ directory, its CSS build subdirectory now needs to be added to the list of directories whose changes are ignored by git. This was previously handled by dw-nonfree's .gitignore file.