### PR TITLE
Enable full screen video in embeds

### DIFF
--- a/cgi-bin/LJ/EmbedModule.pm
+++ b/cgi-bin/LJ/EmbedModule.pm
@@ -233,7 +233,7 @@ sub parse_module_embed {
                     push @stack, $tag;
                 }
 
-                # append the tag contents to new embed buffer, so we can convert in to lj-embed later
+               # append the tag contents to new embed buffer, so we can convert in to lj-embed later
                 $embed .= $reconstructed;
             }
             else {
@@ -249,7 +249,7 @@ sub parse_module_embed {
                     # update tag balance, but only if we have a valid balance up to this moment
                     pop @stack if $stack[-1] eq $tag;
 
-                    # switch to REGULAR if tags are balanced (stack is empty), stay in IMPLICIT otherwise
+               # switch to REGULAR if tags are balanced (stack is empty), stay in IMPLICIT otherwise
                     $newstate = REGULAR unless @stack;
                 }
                 elsif ( $type eq 'S' ) {

--- a/cgi-bin/LJ/EmbedModule.pm
+++ b/cgi-bin/LJ/EmbedModule.pm
@@ -233,7 +233,7 @@ sub parse_module_embed {
                     push @stack, $tag;
                 }
 
-               # append the tag contents to new embed buffer, so we can convert in to lj-embed later
+                # append the tag contents to new embed buffer, so we can convert in to lj-embed later
                 $embed .= $reconstructed;
             }
             else {
@@ -249,7 +249,7 @@ sub parse_module_embed {
                     # update tag balance, but only if we have a valid balance up to this moment
                     pop @stack if $stack[-1] eq $tag;
 
-               # switch to REGULAR if tags are balanced (stack is empty), stay in IMPLICIT otherwise
+                    # switch to REGULAR if tags are balanced (stack is empty), stay in IMPLICIT otherwise
                     $newstate = REGULAR unless @stack;
                 }
                 elsif ( $type eq 'S' ) {
@@ -642,7 +642,7 @@ sub module_iframe_tag {
 qq{//$LJ::EMBED_MODULE_DOMAIN/?journalid=$journalid&moduleid=$moduleid&preview=$preview&auth_token=$auth_token};
     my $iframe_tag =
 qq {<div class="lj_embedcontent-wrapper" style="$wrapper_style"><div class="lj_embedcontent-ratio" style="$ratio_style"><iframe src="$iframe_link"}
-        . qq{ width="$width$width_unit" height="$height$height_unit" allowtransparency="true" frameborder="0"}
+        . qq{ width="$width$width_unit" height="$height$height_unit" allowtransparency="true" frameborder="0" allowfullscreen="true"}
         . qq{ class="lj_embedcontent" id="$id" name="$name"></iframe></div></div>}
         . qq{$direct_link};
 

--- a/t/cleaner-embed.t
+++ b/t/cleaner-embed.t
@@ -17,7 +17,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 175;
+use Test::More tests => 189;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -522,7 +522,7 @@ qq{foo <site-embed><iframe src="http://www.youtube.com/embed/ABC123abc_-"></site
         # make sure that the only top-level iframes we have are the ones we generated
         if ( $viewed_entry =~ "<iframe" ) {
             my $userid = $u->userid;
-            my %attrs  = $viewed_entry =~ /(id|name|class|src)="?([^"]+)"?/g;
+            my %attrs  = $viewed_entry =~ /(id|name|class|src|allowfullscreen)="?([^"]+)"?/g;
             is( $attrs{id}, "embed_${userid}_1", "iframe id: $title" );
             like( $attrs{name}, qr!embed_${userid}_1_[\w]{5}!, "iframe name: $title" );
             is( $attrs{class}, "lj_embedcontent", "iframe class: $title" );
@@ -531,6 +531,7 @@ qq{foo <site-embed><iframe src="http://www.youtube.com/embed/ABC123abc_-"></site
                 qr!^(https?:)?//$LJ::EMBED_MODULE_DOMAIN/\?journalid=!,
                 "iframe src: $title"
             );
+            is( $attrs{allowfullscreen}, "true", "iframe allowfullscreen: $title" );
         }
 
         # check the iframe contents


### PR DESCRIPTION
CODE TOUR: iframes insides iframes, all must be in agreement to enable full screen video for embeds.

* Adds allowfullscreen="true" to the outer embed iframe. allowfullscreen must be set on both iframes (the user-created embed as well as the container iframe) to enable full screen video for embeds. If the user does not set it on each embedded video it will remain disabled.
* Adds test to ensure allowfullscreen="true" on the outer iframe.

With special thanks to alierak.

Fixes #2995