### PR TITLE
[#2925] display edit link when viewer has faqedit priv

### DIFF
--- a/cgi-bin/DW/Controller/Support/Faq.pm
+++ b/cgi-bin/DW/Controller/Support/Faq.pm
@@ -166,9 +166,11 @@ sub faqbrowse_handler {
     my $GET    = $r->get_args;
     my $user;
     my $user_url;
-    my $vars;
+    my $vars = {};
 
     if ($remote) {
+        $vars->{remote} = $remote;
+
         $user     = $remote->user;
         $user_url = $remote->journal_base;
     }


### PR DESCRIPTION
CODE TOUR: Restore "Edit this FAQ" link visible to users with faqedit privs.

Another minor bit of admin functionality that went walkabout when the page was converted away from BML.

Fixes #2925.

