### PR TITLE
Stats fixes

### DIFF
--- a/cgi-bin/DW/Controller/Stats.pm
+++ b/cgi-bin/DW/Controller/Stats.pm
@@ -183,9 +183,6 @@ sub main_handler {
     }
 
     my %graphs = ( newbyday => 'stats/newbyday.png' );
-    foreach ( keys %graphs ) {
-        delete $graphs{$_} unless -f "$LJ::HTDOCS/$graphs{$_}";
-    }
 
     my $vars = {
         stat             => \%stat,

--- a/doc/dependencies-system
+++ b/doc/dependencies-system
@@ -8,6 +8,7 @@ libdbi-perl
 libdbd-mysql-perl
 libgd-gd2-perl
 libgd-graph-perl
+libgd-text-perl
 libpng-dev
 perlmagick
 libapache2-mod-perl2


### PR DESCRIPTION
CODE TOUR: Some graphs for the site statistics pages went missing when we changed webservers, for different obscure reasons.
- Remove test for existence of stats files on this particular webserver, since they may be hosted elsewhere
- Add libgd-text-perl dependency for text in stats bar graphs