### PR TITLE
final (for now) round of tellafriend fixes

### DIFF
--- a/cgi-bin/DW/Controller/Tools.pm
+++ b/cgi-bin/DW/Controller/Tools.pm
@@ -573,7 +573,7 @@ sub tellafriend_handler {
     my $vars = {
         'u'                  => $u,
         'errors'             => $errors,
-        'formdata'           => $r->post_args || $default_formdata,
+        'formdata'           => $r->did_post ? $r->post_args : $default_formdata,
         'display_msg'        => $display_msg,
         'display_msg_footer' => $display_msg_footer,
         'email_checkbox'     => $email_checkbox

--- a/cgi-bin/DW/Controller/Tools.pm
+++ b/cgi-bin/DW/Controller/Tools.pm
@@ -450,12 +450,13 @@ sub tellafriend_handler {
         }
 
         # Check for images
-        if ( $post_args->{'body'} =~ /<(img|image)\s+src/i ) {
+        my $custom_body = $post_args->{'body'} // '';
+        if ( $custom_body =~ /<(img|image)\s+src/i ) {
             $errors->add( 'body', ".error.forbiddenimages" );
         }
 
         # Check for external URLs
-        foreach ( LJ::get_urls( $post_args->{'body'} ) ) {
+        foreach ( LJ::get_urls($custom_body) ) {
             if ( $_ !~ m!^https?://([\w-]+\.)?$LJ::DOMAIN(/.*)?$!i ) {
                 $errors->add( 'body', ".error.forbiddenurl", { sitename => $LJ::SITENAME } );
             }
@@ -469,8 +470,8 @@ sub tellafriend_handler {
             # All valid, go ahead and send
 
             my $msg_body = $post_args->{'body_start'};
-            if ( $post_args->{'body'} ne '' ) {
-                $msg_body .= $custom_msg . "\n-----\n" . $post_args->{'body'} . "\n-----";
+            if ( $custom_body ne '' ) {
+                $msg_body .= $custom_msg . "\n-----\n" . $custom_body . "\n-----";
             }
             $msg_body .= $msg_footer;
 

--- a/cgi-bin/DW/Controller/Tools.pm
+++ b/cgi-bin/DW/Controller/Tools.pm
@@ -478,11 +478,14 @@ sub tellafriend_handler {
             LJ::send_mail(
                 {
                     'to'       => $toemail,
-                    'from'     => $u->{'emailpref'},
+                    'from'     => $LJ::BOGUS_EMAIL,
                     'fromname' => $u->user . LJ::Lang::ml("$scope.via") . " $LJ::SITENAMESHORT",
                     'charset'  => 'utf-8',
                     'subject'  => $post_args->{'subject'},
                     'body'     => $msg_body,
+                    'headers'  => {
+                        'Reply-To' => qq{"$u->{user}" <$u->{emailpref}>},
+                    }
                 }
             );
 

--- a/views/tools/tellafriend.tt
+++ b/views/tools/tellafriend.tt
@@ -8,8 +8,14 @@
 [% form.hidden(name = 'itemid', value = formdata.itemid) %]
 
 [% ".email.fromfield" | ml %]
-[% (u.name || u.user) | html %] &lt;[% u.emailpref %]&gt;
-<p>
+"[% u.user | html %] [% '.via' | ml %] [% site.nameshort | html %]"
+<br>
+[% ".email.field.subject" | ml %]
+[% formdata.subject | html %]
+<br>
+[% ".email.field.replyto" | ml %]
+"[% u.user | html %]" &lt;[% u.emailpref %]&gt;
+<p style="margin-top: 1em">
 [% form.textbox(
         label = dw.ml(".email.recipientfield"), 
         name = 'toemail', 

--- a/views/tools/tellafriend.tt.text
+++ b/views/tools/tellafriend.tt.text
@@ -38,6 +38,10 @@ Here's a link to the journal that I'm keeping online:
 
 .
 
+.email.field.replyto=Reply-To:
+
+.email.field.subject=Subject:
+
 .email.formatinfo=comma separated, maximum of 150 characters
 
 .email.fromfield=From:


### PR DESCRIPTION
CODE TOUR: more fixes for the /tools/tellafriend page

Currently, the header of the generated email looks like:

> From: "[[username]] via [[sitename]]" <[[user's email]]>

This updates it to come from $LJ::BOGUS_EMAIL, with the user's email as a reply-to:

> From: "[[username]] via [[sitename]]" <[[dw_null@site]]>
> Reply-To: "[[username]]" <[[user's email]]>

This change also makes it more likely that the message will actually be delivered by SES.

Fixes #1866 plus a few other conversion bugs that cropped up in testing.