### PR TITLE
Rename hangouts to chat

### DIFF
--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -441,10 +441,10 @@ userproplist.github:
 userproplist.google_talk:
   cldversion: 0
   datatype: char
-  des: Google's 'Hangouts' Service address
+  des: Google Chat Service address
   indexed: 1
   multihomed: 1
-  prettyname: Google Hangouts Address
+  prettyname: Google Chat Address
 
 userproplist.google_analytics:
   cldversion: 4

--- a/htdocs/manage/profile/index.bml.text
+++ b/htdocs/manage/profile/index.bml.text
@@ -1,5 +1,5 @@
 ;; -*- coding: utf-8 -*-
-.chat.googlehangouts=Google Hangouts
+.chat.googlehangouts=Google Chat
 
 .chat.icquin=ICQ UIN
 

--- a/views/profile/main.tt.text
+++ b/views/profile/main.tt.text
@@ -115,7 +115,7 @@
 
 .service.github=GitHub
 
-.service.hangouts=Google Hangouts
+.service.hangouts=Google Chat
 
 .service.icq=ICQ
 


### PR DESCRIPTION
CODE TOUR: Rename Google Hangouts to Google Chat. Fixes #3002.