### PR TITLE
uncompress comment subject after retrieving from db

### DIFF
--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -2658,6 +2658,7 @@ sub get_talktext2 {
         $sth->execute;
         while ( my ( $id, $subject, $body ) = $sth->fetchrow_array ) {
             $subject = "" unless defined $subject;
+            LJ::text_uncompress( \$subject );
             $body    = "" unless defined $body;
             LJ::text_uncompress( \$body );
             $lt->{$id} = [ $subject, $body ];


### PR DESCRIPTION
CODE TOUR: Avoid displaying gibberish in the extremely rare case where a comment subject was stored in gzip format.

Fixes #2524
