### PR TITLE
try again with warning users off buying regular paid time for premium accounts

### DIFF
--- a/cgi-bin/LJ/Widget/ShopItemOptions.pm
+++ b/cgi-bin/LJ/Widget/ShopItemOptions.pm
@@ -176,14 +176,53 @@ sub handle_post {
     # build a new item and try to toss it in the cart.  this fails if there's a
     # conflict or something
     if ( $post->{accttype} ) {
-        my ( $rv, $err ) = $cart->add_item(
-            DW::Shop::Item::Account->new(
-                type           => $post->{accttype},
-                user_confirmed => $post->{alreadyposted},
-                force_spelling => $post->{force_spelling},
-                %item_data
-            )
+
+        my $item = DW::Shop::Item::Account->new(
+            type           => $post->{accttype},
+            user_confirmed => $post->{alreadyposted},
+            force_spelling => $post->{force_spelling},
+            %item_data
         );
+
+        # check for renewing premium as paid
+        if ( my $u = LJ::load_userid( $item ? $item->t_userid : undef ) ) {
+
+            my $paid_status  = DW::Pay::get_paid_status($u) || {};
+            my $paid_curtype = DW::Pay::type_shortname( $paid_status->{typeid} // '' );
+            my $has_premium  = $paid_curtype eq 'premium' ? 1 : 0;
+
+            if ( $has_premium && $item->class eq 'paid' && !$post->{prem_convert} ) {
+
+                # check account expiration date
+                my $exptime = DateTime->from_epoch( epoch => $paid_status->{expiretime} );
+                my $newtime = DateTime->now;
+
+                if ( my $future_ymd = $item->deliverydate ) {
+                    my ( $y, $m, $d ) = split /-/, $future_ymd;
+                    $newtime = DateTime->new( year => $y + 0, month => $m + 0, day => $d + 0 );
+                }
+
+                my $to_day = sub { return $_[0]->truncate( to => 'day' ) };
+
+                if ( DateTime->compare( $to_day->($exptime), $to_day->($newtime) ) ) {
+                    my $months = $item->months;
+                    my $newexp = $exptime->clone->add( months => $months );
+                    my $paid_d = $exptime->delta_days($newexp)->in_units('days');
+                    my $prem_d = int( $paid_d * 0.7 );
+
+                    my $ml_args =
+                        { date => $exptime->ymd, premium_num => $prem_d, paid_num => $paid_d };
+
+                    # but only include date if the logged-in user owns the account
+                    delete $ml_args->{date} unless $remote && $remote->has_same_email_as($u);
+
+                    # this should be handled as a special case in the caller
+                    return ( error => 'premium_convert', ml_args => $ml_args );
+                }
+            }
+        }
+
+        my ( $rv, $err ) = $cart->add_item($item);
         return ( error => $err ) unless $rv;
     }
     elsif ( $post->{item} eq "rename" ) {

--- a/htdocs/shop/account.bml
+++ b/htdocs/shop/account.bml
@@ -69,24 +69,39 @@ body<=
 
     my $post_fields = {};
     my $email_checkbox;
+    my $premium_convert;
+
     if ( LJ::did_post() ) {
         return "<?h1 $ML{'Error'} h1?><?p $ML{'error.invalidform'} p?>"
             unless LJ::check_form_auth();
 
         my $error;
+        my %from_post;
+
         $post_fields = LJ::Widget::ShopItemOptions->post_fields( \%POST );
+
         if ( keys %$post_fields ) { # make sure the user selected an account type
             # need to do this because all of these form fields are in the BML page instead of in the widget
             LJ::Widget->use_specific_form_fields( post => \%POST,
                                                   widget => "ShopItemOptions",
-                                                  fields => [ qw( for username email deliverydate_mm deliverydate_dd deliverydate_yyyy anonymous reason alreadyposted force_spelling ) ] );
-            my %from_post = LJ::Widget->handle_post( \%POST, 'ShopItemOptions' => { email_checkbox => \$email_checkbox } );
+                                                  fields => [ qw( for username email deliverydate_mm deliverydate_dd deliverydate_yyyy anonymous reason alreadyposted force_spelling prem_convert ) ] );
+            %from_post = LJ::Widget->handle_post( \%POST, 'ShopItemOptions' => { email_checkbox => \$email_checkbox } );
             $error = $from_post{error} if $from_post{error};
         } else {
             $error = $ML{'.error.noselection'};
         }
 
-        if ( $error ) {
+        if ( $error eq 'premium_convert' ) {
+            $premium_convert = 1;
+
+            my $ml_args = $from_post{ml_args};
+
+            $ret .= qq{<div class="error-box">};
+            $ret .= BML::ml( '.error.premiumconvert', $ml_args );
+            $ret .= BML::ml( '.error.premiumconvert.postdate', $ml_args ) if $ml_args->{date};
+            $ret .= qq{</div>};
+
+        } elsif ( $error ) {
             $ret .= qq{<div class="error-box">$error</div>};
         } else {
             return BML::redirect( "$LJ::SITEROOT/shop" );
@@ -169,6 +184,13 @@ body<=
     }
 
 	$ret .= "</table>";
+
+	if ( $premium_convert ) {
+		$ret .= "<p>";
+		$ret .= LJ::html_check( { name => 'prem_convert', id => 'prem_convert', value => 1 } );
+		$ret .= "<label for='prem_convert'>$ML{'.premiumconvert.agree'}</label>";
+		$ret .= "</p>";
+	}
 
     $ret .= LJ::html_hidden( for => $GET{for} );
     $ret .= LJ::html_hidden( alreadyposted => 1 ) if LJ::did_post();

--- a/htdocs/shop/account.bml
+++ b/htdocs/shop/account.bml
@@ -85,8 +85,17 @@ body<=
             LJ::Widget->use_specific_form_fields( post => \%POST,
                                                   widget => "ShopItemOptions",
                                                   fields => [ qw( for username email deliverydate_mm deliverydate_dd deliverydate_yyyy anonymous reason alreadyposted force_spelling prem_convert ) ] );
-            %from_post = LJ::Widget->handle_post( \%POST, 'ShopItemOptions' => { email_checkbox => \$email_checkbox } );
-            $error = $from_post{error} if $from_post{error};
+
+            @BMLCodeBlock::errors = (); # LJ::Widget->handle_post uses this global variable
+            eval { %from_post = LJ::Widget->handle_post( \%POST, 'ShopItemOptions' => { email_checkbox => \$email_checkbox } ); };
+
+            my @errs = map { LJ::ehtml($_) } split "\n", $BMLCodeBlock::errors[0] // '';
+            push @errs, $@ if $@;
+            if ( $from_post{error} && ( !@errs || $from_post{error} ne 'premium_convert' ) ) {
+                push @errs, $from_post{error};
+            }
+            $error = join "<br>", @errs;
+
         } else {
             $error = $ML{'.error.noselection'};
         }

--- a/htdocs/shop/account.bml.text
+++ b/htdocs/shop/account.bml.text
@@ -9,6 +9,26 @@
 
 .error.noselection=You must select an item to add to your cart.
 
+.error.premiumconvert<<
+<p>
+The selected account is currently a premium paid account, but you've chosen
+to purchase regular paid time. A premium paid account can't be downgraded to a
+paid account. If you choose to proceed, the paid time you purchase will be
+converted to premium paid time at our standard conversion rate of 70% when it's applied
+to the account, granting [[premium_num]] more days of premium paid time instead of
+the [[paid_num]] more days you might have expected.
+</p>
+.
+
+.error.premiumconvert.postdate<<
+<p>
+If you want to renew the account as a paid account, instead of a premium paid account,
+you'll need to adjust your order so that the paid time is scheduled to be applied on
+or after the account's expiration date of [[date]]. Doing this may result in up to a
+day's wait before the paid time is applied to the account.
+</p>
+.
+
 .giftfor.anonymous=Do you want to make this an anonymous gift?
 
 .giftfor.deliverydate=Delivery date:
@@ -28,6 +48,8 @@
 .intro.random=Please choose the type of paid account that you'd like to purchase for a random active free account.
 
 .intro.self=Please choose the type of <a [[aopts]]>Paid Account</a> that you'd like to purchase for your account [[user]].
+
+.premiumconvert.agree=Yes, I want to purchase standard paid time for this premium paid account, which will be converted to a smaller amount of premium paid time if it is applied before the account expires.
 
 .title=Buy a Paid Account
 


### PR DESCRIPTION
CODE TOUR: This brings back the part of #3008 we had to pull out when it broke the shop. It displays a nice shiny warning to people trying to buy regular paid time for a premium account...

... but only if they are actually allowed to do so...

... and it also fixes the underlying issue that was sending the cart widget errors into a black hole.

__PLEASE TEST ON CANARY BEFORE DEPLOYING.__

Fixes #3013.