### PR TITLE
limit directory search by location results to visible users

### DIFF
--- a/cgi-bin/LJ/Directory/Constraint/Location.pm
+++ b/cgi-bin/LJ/Directory/Constraint/Location.pm
@@ -93,10 +93,11 @@ sub matching_uids {
     my $prefix = join( "-", $country, $state, $city );
     $prefix =~ s/\%-\%$/%/;        # Country-%-%  --> Country-%
 
-    my $uids =
-        $db->selectcol_arrayref( "SELECT userid FROM userprop WHERE upropid=? AND value LIKE ?",
-        undef, $p->{id}, $prefix )
-        || [];
+    # for efficiency, do a table join here to filter on visible users
+    my $uids = $db->selectcol_arrayref(
+"SELECT up.userid FROM userprop AS up INNER JOIN user AS u ON up.userid=u.userid WHERE up.upropid=? AND u.statusvis='V' AND up.value LIKE ?",
+        undef, $p->{id}, $prefix
+    ) || [];
     return @$uids;
 }
 


### PR DESCRIPTION
I took my cue from ContactInfo.pm, which mentions a desire to avoid using load_userids on a large data set for filtering purposes. Instead this expresses the visibility requirement as an additional WHERE clause in the SELECT statement, acting only on users that have rows in both the user and userprop tables.

Obviously my ability to test this locally is extremely limited, but this should fix the problem with location results being sparsely populated due to a large number of suspended SEO accounts.

CODE TOUR: Update directorysearch results to exclude suspended and deleted users when searching by location.