### PR TITLE
fix table header background color on Foundation pages

### DIFF
--- a/htdocs/scss/skins/_page-layout-hacks.scss
+++ b/htdocs/scss/skins/_page-layout-hacks.scss
@@ -32,6 +32,10 @@ ul.successlinks li {
 }
 
 // fix for illegible table header links
+[id="content"] table thead {
+    background-color: $soft-accent-color;
+}
+
 [id="content"] table thead th a {
     color: $primary-text-color;
 }


### PR DESCRIPTION
I found where the table header link colors were specified and dropped in a rule for a background color so that the links would be legible again.

It was very obvious on the admin/statushistory page, but this should affect any Foundation pages with similarly defined table header elements.

I don't know if this is the best solution, but it seems like an improvement. I did check legibility in all the different site schemes.

CODE TOUR: Specify a background color for table header rows on site-schemed Foundation pages.