### PR TITLE
Remove high-byte check from CSS cleaner (it messes with utf8)

### DIFF
--- a/cgi-bin/CSS/Cleaner.pm
+++ b/cgi-bin/CSS/Cleaner.pm
@@ -89,11 +89,6 @@ sub _stupid_clean {
         return;
     }
 
-    if ( $reduced =~ /[\x7f-\xff]/ ) {
-        $$ref = "/* suspect CSS: high bytes */";
-        return;
-    }
-
     # returns 1 if something bad was found
     my $check_for_bad = sub {
         if ( $reduced =~ m!<\w! ) {


### PR DESCRIPTION
CODE TOUR:  Back in Ye Olden Days of the web, nobody used unicode, and it was possible to make browsers do undesirable things by injecting non-printing control characters into CSS. The CSS cleaner had a very basic check for this, but these days browsers handle this situation much better, *and* it also catches unicode characters that are valid in CSS, so in the interests of not driving people up the wall with a security feature we don't need any more, it has been removed.