### PR TITLE
more generic fix for legacy country codes

### DIFF
--- a/cgi-bin/DW/Controller/Shop/CreditCard.pm
+++ b/cgi-bin/DW/Controller/Shop/CreditCard.pm
@@ -132,7 +132,6 @@ sub enter_cc_handler {
         # load country codes, and US states
         my ( %countries, %usstates );
         DW::Countries->load( \%countries );
-        delete $countries{UK};    # UK is also GB; don't display both
         LJ::load_codes( { state => \%usstates } );
 
         # now sort the above appropriately

--- a/cgi-bin/DW/Controller/Stats.pm
+++ b/cgi-bin/DW/Controller/Stats.pm
@@ -57,7 +57,7 @@ sub main_handler {
     {    # load country and state stats
 
         my %countries;
-        DW::Countries->load( \%countries );
+        DW::Countries->load_legacy( \%countries );
         $sth = $dbr->prepare(
             "SELECT statkey, statval FROM stats WHERE statcat='country'
             ORDER BY statval DESC LIMIT 15"

--- a/cgi-bin/DW/Countries.pm
+++ b/cgi-bin/DW/Countries.pm
@@ -48,7 +48,21 @@ sub load {
     foreach my $code ( all_country_codes() ) {
         $countries->{ uc $code } = code2country($code);
     }
-    $countries->{UK} = $countries->{GB};
+}
+
+=head2 C<< DW::Countries->load_legacy( $hashref ) >>
+
+Adds some additional legacy codes for displaying older data where appropriate.
+
+=cut
+
+sub load_legacy {
+    my ( $class, $countries ) = @_;
+
+    $class->load($countries);
+
+    $countries->{LJSC} = $countries->{GB};    # Scotland
+    $countries->{UK}   = $countries->{GB};    # United Kingdom
 }
 
 1;

--- a/cgi-bin/DW/Logic/ProfilePage.pm
+++ b/cgi-bin/DW/Logic/ProfilePage.pm
@@ -471,7 +471,7 @@ sub _basic_info_location {
 
         if ($country) {
             my %countries = ();
-            DW::Countries->load( \%countries );
+            DW::Countries->load_legacy( \%countries );
 
             $country_ret = {};
             $country_ret->{url} = "$dirurl&amp;loc_cn=$ecountry"

--- a/cgi-bin/LJ/Widget/Location.pm
+++ b/cgi-bin/LJ/Widget/Location.pm
@@ -238,7 +238,7 @@ sub handle_post {
 
     # load country codes
     my %countries;
-    DW::Countries->load( \%countries );
+    DW::Countries->load_legacy( \%countries );
 
     my $state_inline_desc   = $class->ml('widget.location.fn.state.inline2');
     my $state_from_dropdown = $class->ml('states.head.defined');
@@ -315,10 +315,6 @@ sub country_options {
 
     # load country codes
     DW::Countries->load( \%countries );
-    delete $countries{UK}
-        ;    # we need to include UK in the hash for legacy reasons -- some users still have
-             # their country set as UK -- but UK is mapped to GB, so there's no need to confuse
-             # users by offering them expansions of both "UK" and "GB" in the drop-down.
 
     my $options = [
         ''   => $class->ml('widget.location.country.choose'),


### PR DESCRIPTION
Years ago, we changed our source of country code data to use a standard CPAN module.  This has largely worked well except for a couple of odd corner cases where the previous country code stored in user data didn't match up with the new source.  The obvious one was the change from UK to GB, so we kludged in recognition for both codes, and then deleted the older one anywhere it showed up as a duplicate in a drop down menu.

Subsequently it was noted that there was a legacy code for Scotland (LJSC) which needed the same treatment. Instead of continuing to expand the kludge, this adds a second class method, load_legacy, to use when requesting the version of the data that includes the older codes. That way we can go back to calling the basic load method without having to then delete the extra codes in the caller. And if we stumble across any other missing codes, they'll be maintained in one place.

Fixes #2197.

CODE TOUR: Fixes "error in linkification" message for profiles using a legacy country code for Scotland, and makes it easier for devs to patch in other missing country codes.