### PR TITLE
Update comments to match license stated, add link

### DIFF
--- a/ext/dw-nonfree/views/legal/dmca.tt
+++ b/ext/dw-nonfree/views/legal/dmca.tt
@@ -7,10 +7,9 @@
   #
   # Copyright (c) 2009 by Dreamwidth Studios, LLC.
   #
-  # This program is NOT free software or open-source; you can use it as an
-  # example of how to implement your own site-specific extensions to the
-  # Dreamwidth Studios open-source code, but you cannot use it on your site
-  # or redistribute it, with or without modifications.
+  # This program is free software; you may redistribute it and/or modify it
+  # or redistribute it, with or without modifications, subject to the 
+  # license terms stated in the text.
   #
 %]
 
@@ -115,4 +114,5 @@
 
 <p>We also reserve the right to terminate the accounts of those who, in our opinion, misuse or abuse the DMCA notification process against other users.</p>
 
-<p>This policy is licensed under a Creative Commons Attribution-ShareAlike 2.5 License.</p>
+<p>This policy is licensed under the 
+<a href="https://creativecommons.org/licenses/by-sa/2.5/legalcode">Creative Commons Attribution-ShareAlike 2.5 License</a>.</p>


### PR DESCRIPTION
Although the license stated in the text is CC-by-SA-2.5, the comments in the header stated inconsistent information apparently left over from use of that header in a code file. This pull request updates the comments to be consistent with the license stated, and adds a link to the license as required by the license terms for its use. I would like to fix these issues before making a copy to use on our own site with appropriate alterations and credit as per the license.

CODE TOUR: no-impact