### PR TITLE
Update comments to match license stated, add link

### DIFF
--- a/views/legal/privacy.tt
+++ b/views/legal/privacy.tt
@@ -8,8 +8,8 @@
   # Copyright (c) 2009 by Dreamwidth Studios, LLC.
   #
   # This program is free software; you may redistribute it and/or modify it
-  # under the same terms as Perl itself.  For a copy of the license, please
-  # reference 'perldoc perlartistic' or 'perldoc perlgpl'.
+  # or redistribute it, with or without modifications, subject to the 
+  # license terms stated in the text.
   #
 %]
 
@@ -167,6 +167,7 @@
 
 <h2>Creative Commons</h2>
 
-<p>This privacy policy is based on one developed by Automattic (http://automattic.com/privacy/) and is licensed under a Creative Commons Attribution-ShareAlike 2.5 License.</p>
+<p>This privacy policy is based on one developed by Automattic (http://automattic.com/privacy/) and is licensed under the 
+<a href="https://creativecommons.org/licenses/by-sa/2.5/legalcode">Creative Commons Attribution-ShareAlike 2.5 License</a>.</p>
 
 <p class='note'>Last revised June 6, 2010</p>


### PR DESCRIPTION
Although the license stated in the text is CC-by-SA-2.5, the comments in the header stated inconsistent information apparently left over from use of that header in a code file. This pull request updates the comments to be consistent with the license stated, and adds a link to the license as required by the license terms for its use. I would like to fix these issues before making a copy to use on our own site with appropriate alterations and credit as per the license.

CODE TOUR: no-impact