### PR TITLE
Add basic support for navlinks in headers in core2

### DIFF
--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -1914,7 +1914,17 @@ property string[] module_navlinks_group {
 set module_navlinks_group = ["module_navlinks_show", "module_navlinks_order", "module_navlinks_section"];
 property bool module_navlinks_show { grouped = 1; }
 property int  module_navlinks_order { grouped = 1; }
-property string module_navlinks_section { grouped = 1; }
+property string module_navlinks_section { 
+    grouped = 1; }
+
+# Looks silly and redundant, but necessary to have the 'Header' section show up properly in the customization wizard
+# without allowing *every* module to be put in the header
+property string module_navlinks_section_override {
+    values = "none|(none)|header|Header|one|Main Module Section|two|Secondary Module Section";
+    grouped = 1;
+}
+
+set grouped_property_override = { "module_navlinks_section" => "module_navlinks_section_override" };
 
 property string[] module_calendar_group {
     des = "Calendar";
@@ -4907,6 +4917,7 @@ function Page::print()
                 <div class="inner">
                     """;
                     $this->print_header();
+                    $this->print_module_section("header");
     """
                 </div><!-- end header>inner -->
             </div><!-- end header -->

--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -311,6 +311,33 @@ function Page::print_default_stylesheet() {
     var string module_font = generate_font_css($*font_module_text, $*font_base, $*font_fallback, $*font_module_text_size, $*font_module_text_units);
     var string module_title_font = generate_font_css($*font_module_heading, $*font_base, $*font_fallback, $*font_module_heading_size, $*font_module_heading_units);
 
+    #for showing the navigation in the header
+    var string navlinks_css = "";
+    if ( $*module_navlinks_section == "header" ) { $navlinks_css = """
+        #header > .inner:first-child { padding-bottom: 2em;
+            position: relative; }
+        .module-navlinks { text-align:right;}
+        .module-navlinks * {
+        display: inline !important;
+        background:  transparent !important;
+        border-left: none !important; }
+
+        /* Above standard link colors so hover and active still work */
+        .module-navlinks .module-content li a.current,
+        .module-navlinks .module-content li a.current:visited {
+            color: $*color_page_title;
+            text-decoration: none;
+        }
+
+        /* Extra specificity needed to override code below */
+        .module-navlinks .module-content li a { color: $*color_header_link; }
+        .module-navlinks .module-content li a:visited { color: $*color_header_link_visited; }
+        .module-navlinks .module-content li a:hover { color: $*color_header_link_hover; }
+        .module-navlinks .module-content li a:active { color: $*color_header_link_active; }
+
+        .module-navlinks .module-header { display: none !important; }
+        """; }
+    else { $navlinks_css = ""; }
 
      var string userpic_css = "";
          if ($*userpics_position == "right") {
@@ -876,5 +903,7 @@ ul.userlite-interaction-links.text-links {
 }
 
 $userpic_css
+
+$navlinks_css
     """;
 }

--- a/styles/fluidmeasure/layout.s2
+++ b/styles/fluidmeasure/layout.s2
@@ -71,6 +71,7 @@ function Page::print()
                 <div class="inner">
                     """;
                     $this->print_header();
+                    $this->print_module_section("header");
     """
                 </div><!-- end header>inner -->
             </div><!-- end header -->


### PR DESCRIPTION
CODE TOUR: For a long time, some layouts had the option to display navigation links (Recent Entries/Archive/Reading/Tags/etc) in the header, and some did not, and you couldn't really tell which did without applying the layout and going in to reorder the modules. So... why not make it a standard option? This is step one of that, which is to say, basically all the layouts that use the common main area/sidebar pattern now have the option to put the navlinks in the header, but it may not look super-nice by default in all of them

---
I figured 'perfect' was the enemy of 'done' so this adds basic support (and some VERY basic styling for Tabula Rasa-based layouts), and I will open another issue to handle adding additional styling.

Fixes #674 