### PR TITLE
also don't allow gifts of premium time for paid accounts

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -3831,6 +3831,8 @@ shop.item.account.canbeadded.nopaidforpremium=[[user]] has a Premium Paid Accoun
 
 shop.item.account.canbeadded.noperms=There are no more seed accounts available for purchase at this time.
 
+shop.item.account.canbeadded.nopremiumforpaid=[[user]] cannot receive a Premium Paid Account as a gift directly, because it would reduce the duration of their existing paid time. If you're sure they would welcome the upgrade, you can send them enough points to pay for the premium time.
+
 shop.item.account.canbeadded.notactive=[[user]] is not currently active. Submit your order again to confirm that you want to buy them paid time.
 
 shop.item.account.conflicts.differentpaid=You cannot purchase two different types of paid accounts for the same person.

--- a/cgi-bin/DW/Shop/Item/Account.pm
+++ b/cgi-bin/DW/Shop/Item/Account.pm
@@ -378,7 +378,14 @@ sub can_be_added {
             $$errref = LJ::Lang::ml(
                 'shop.item.account.canbeadded.nopaidforpremium',
                 { user => $target_u->ljuser_display }
-            );
+            ) if $self->class eq 'paid';
+
+            # paid accounts can't get premium time as a gift
+            $$errref = LJ::Lang::ml(
+                'shop.item.account.canbeadded.nopremiumforpaid',
+                { user => $target_u->ljuser_display }
+            ) if $self->class eq 'premium';
+
             return 0;
         }
     }
@@ -386,9 +393,7 @@ sub can_be_added {
     return 1;
 }
 
-# this checks whether we can downgrade the premium to paid
-# FIXME: a better fix for this is to have an autorenewal system, and have the paid time
-# applied to their account once their current premium time expires
+# this checks whether we can upgrade/downgrade between premium & paid
 sub allow_account_conversion {
     my ( $class, $u, $to ) = @_;
 
@@ -401,11 +406,21 @@ sub allow_account_conversion {
 
     my $from = DW::Pay::type_shortname( $paid_status->{typeid} );
 
-    # doesn't match premium => paid, so allow it
-    return 1 unless $from eq 'premium' && $to eq 'paid';
+    # ok unless we're going from premium to paid or paid to premium
+    my $changing = 0;
+
+    $changing = 1 if $from eq 'premium' && $to eq 'paid';
+    $changing = 1 if $from eq 'paid'    && $to eq 'premium';
+
+    # doesn't match either scenario, so allow it
+    return 1 unless $changing;
 
     # allow if we're within two weeks of expiration
     return 1 if $paid_status->{expiresin} <= 3600 * 24 * 14;
+
+    # allow upgrading to premium if the remote user owns this account
+    my $remote = LJ::get_remote();
+    return 1 if $to eq 'premium' && $remote && $remote->has_same_email_as($u);
 
     return 0;
 }


### PR DESCRIPTION
Denise brought up the fact that buying premium time for someone else's paid account, while a nice gesture, shouldn't be allowed because it forces the account's existing paid time to be upgraded to a shorter amount of premium paid time. Users can buy premium time for their own paid accounts, but not other people's.

(This was left over from November's shop-tweaking spree. Please test on canary before deploying more widely!)

CODE TOUR: Don't allow users to purchase premium time for paid accounts other than their own.