### PR TITLE
Fix for annoying button flash on initial inbox load

### DIFF
--- a/htdocs/js/jquery.inbox.js
+++ b/htdocs/js/jquery.inbox.js
@@ -226,3 +226,4 @@ function check_selected() {
 }
 
 none_selected();
+$(".action_button").removeClass('no-js');

--- a/htdocs/scss/pages/inbox.scss
+++ b/htdocs/scss/pages/inbox.scss
@@ -149,6 +149,10 @@
   display: block;
 }
 
+.action_button.no-js {
+  display: none;
+}
+
 .selected_filter {
   display: none;
 }

--- a/views/inbox/index.tt
+++ b/views/inbox/index.tt
@@ -1,7 +1,13 @@
 [%- CALL dw.active_resource_group( "foundation" ) -%]
 [% dw.need_res( { group => "foundation" }, 'stc/css/pages/inbox.css', 'js/jquery.inbox.js', 'js/jquery.esn.js', 'js/jquery.commentmanage.js', 'js/jquery.ajaxtip.js' ) %]
 [%- sections.title = '.title' | ml -%]
-
+[%- sections.head = BLOCK %]
+    <noscript>
+    <style type="text/css">
+        .action_button.no-js {display: inline-block !important;}
+    </style>
+    </noscript>
+[% END %]
 <div class="alert-box secondary">[% ".beta.on" | ml( aopts = "href='$site.root/betafeatures'", user = dw_beta.ljuser_display ) %]</div>
 
 <div id="inbox">
@@ -17,9 +23,9 @@
             <div class="header searchhighlight" id="action_row">
                 <div class="checkbox">[% form.checkbox(name = 'check_all', class = 'check_all', value = 'check_all') %]</div>
                 <div class="actions">
-                    [% form.submit(name = 'mark_read', value = dw.ml('widget.inbox.menu.mark_read.btn'), class = 'action_button button small show_unread', 'data-action' = 'mark_read') %]
-                    [% form.submit(name = 'mark_unread', value = dw.ml('widget.inbox.menu.mark_unread.btn'), class = 'action_button button small show_read', 'data-action' =  'mark_unread') %]
-                    [% form.submit(name = 'delete', value = dw.ml('.menu.delete.btn'), class = 'action_button button small show_read show_unread', 'data-action' =  'delete') %]
+                    [% form.submit(name = 'mark_read', value = dw.ml('widget.inbox.menu.mark_read.btn'), class = 'action_button button small show_unread js_hide', 'data-action' = 'mark_read') %]
+                    [% form.submit(name = 'mark_unread', value = dw.ml('widget.inbox.menu.mark_unread.btn'), class = 'action_button button small show_read js_hide', 'data-action' =  'mark_unread') %]
+                    [% form.submit(name = 'delete', value = dw.ml('.menu.delete.btn'), class = 'action_button button small show_read show_unread js_hide', 'data-action' =  'delete') %]
                     [% form.submit(name = 'mark_all', value = dw.ml(mark_all), class = 'action_button button small show_all', 'data-action' = 'mark_all') %]
                     [% form.submit(name = 'delete_all', value = dw.ml(delete_all), class = 'action_button button small show_all', 'data-action' = 'delete_all') %]
                 </div>


### PR DESCRIPTION
CODE TOUR: Part of making the inbox nicer - there would be a second or two of all five action buttons being visible at once before the JS would load and hide some of them. This removes that, while ensuring that  if a user doesn't have JS enabled, they see all five buttons.