### PR TITLE
[#2954] new GoogleAnalytics4 user setting

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2846,6 +2846,10 @@ setting.googleanalytics.error.invalid=Invalid Google Analytics ID entered, must 
 
 setting.googleanalytics.label=Google Analytics ID
 
+setting.googleanalytics4.error.invalid=Invalid Google Analytics ID entered, v4 ID must be of the format: G-XXXXXXXXXX (where X represents alphanumeric characters).
+
+setting.googleanalytics4.label=Google Analytics ID (v4)
+
 setting.graphicpreviews.label=Graphic Previews
 
 setting.graphicpreviews.option.comm=Allow viewers to preview external links within my community

--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -422,6 +422,14 @@ userproplist.friendspagesubtitle:
   multihomed: 0
   prettyname: Friends Page Subtitle
 
+userproplist.ga4_analytics:
+  cldversion: 4
+  datatype: char
+  des: Google Analytics v.4 Code
+  indexed: 1
+  multihomed: 0
+  prettyname: Google Analytics v.4 Code
+
 userproplist.gender:
   cldversion: 4
   datatype: char

--- a/cgi-bin/DW/Setting/GoogleAnalytics4.pm
+++ b/cgi-bin/DW/Setting/GoogleAnalytics4.pm
@@ -1,0 +1,73 @@
+#!/usr/bin/perl
+#
+# DW::Setting::GoogleAnalytics4
+#
+# LJ::Setting module for Google Analytics version 4
+#
+# Authors:
+#      Andrea Nall <anall@andreanall.com>
+#      Jen Griffin <kareila@livejournal.com>
+#
+# Copyright (c) 2009-2023 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+package DW::Setting::GoogleAnalytics4;
+use base 'LJ::Setting';
+use strict;
+use warnings;
+use LJ::Global::Constants;
+
+sub should_render {
+    my ( $class, $u ) = @_;
+
+    return $u && $u->can_use_google_analytics ? 1 : 0;
+}
+
+sub label {
+    return $_[0]->ml('setting.googleanalytics4.label');
+}
+
+sub option {
+    my ( $class, $u, $errs, $args ) = @_;
+
+    my $key = $class->pkgkey;
+    my $ret;
+
+    $ret .= LJ::html_text(
+        {
+            name      => "${key}code",
+            id        => "${key}code",
+            class     => "text",
+            value     => $errs ? $class->get_arg( $args, "code" ) : $u->ga4_analytics,
+            size      => 30,
+            maxlength => 100,
+        }
+    );
+
+    my $errdiv = $class->errdiv( $errs, "code" );
+    $ret .= "<br />$errdiv" if $errdiv;
+
+    return $ret;
+}
+
+sub save {
+    my ( $class, $u, $args ) = @_;
+
+    my $txt = $class->get_arg( $args, "code" ) || '';
+    $txt = LJ::text_trim( $txt, 0, 100 );
+
+    # Check that the ID matches the format G-xxxxxxxxxx
+    # or is blank before proceeding.
+    if ( $txt =~ /^G-[A-Z0-9]{10,}$/i or $txt eq "" ) {
+        $u->ga4_analytics(uc $txt);
+    }
+    else {
+        $class->errors( "code" => $class->ml('setting.googleanalytics4.error.invalid') );
+    }
+    return 1;
+}
+
+1;

--- a/cgi-bin/LJ/User/Permissions.pm
+++ b/cgi-bin/LJ/User/Permissions.pm
@@ -630,6 +630,17 @@ sub google_analytics {
     return $u->prop('google_analytics');
 }
 
+sub ga4_analytics {
+    my $u = shift;
+
+    if ( defined $_[0] ) {
+        $u->set_prop( ga4_analytics => $_[0] );
+        return $_[0];
+    }
+
+    return $u->prop('ga4_analytics');
+}
+
 # is there a suspend note?
 sub get_suspend_note {
     my $u = $_[0];

--- a/htdocs/manage/settings/index.bml
+++ b/htdocs/manage/settings/index.bml
@@ -107,6 +107,7 @@ body<=
                 LJ::Setting::ViewingAdultContent
                 LJ::Setting::SafeSearch
                 DW::Setting::GoogleAnalytics
+                DW::Setting::GoogleAnalytics4
                 DW::Setting::ExcludeOwnStats
                 DW::Setting::StickyEntry
                 DW::Setting::MobileView


### PR DESCRIPTION
CODE TOUR: This is the bare minimum of code needed to allow users to tell us their IDs for use with the new version of Google Analytics. It doesn't do anything with that information yet.

* new module `cgi-bin/DW/Setting/GoogleAnalytics4.pm`, which is more or less a clone of `cgi-bin/DW/Setting/GoogleAnalytics.pm` with tweaks

* both settings modules are retained to allow for a transition period; the labels on /manage/settings are "Google Analytics ID" and "Google Analytics ID (v4)"

* new userprop ga4_analytics

* new user method `ga4_analytics`

I couldn't find a format guideline for the ID values. The setting module enforces a format of "G-" followed by at least 10 alphanumeric characters, saved as uppercase. If that turns out to be wrong, we can tweak it later.
