### PR TITLE
Clean up Perl -> JS dumping

### DIFF
--- a/cgi-bin/DW/Controller/Comments.pm
+++ b/cgi-bin/DW/Controller/Comments.pm
@@ -21,6 +21,8 @@ package DW::Controller::Comments;
 use strict;
 use warnings;
 
+use LJ::JSON;
+
 use DW::Controller;
 use DW::Routing;
 use DW::Template;
@@ -248,7 +250,7 @@ sub received_handler {
         }
     }
 
-    $vars->{LJ_cmtinfo} = LJ::js_dumper( \%LJ_cmtinfo );
+    $vars->{LJ_cmtinfo} = to_json( \%LJ_cmtinfo );
 
     return DW::Template->render_template( 'comments/recent.tt', $vars );
 }
@@ -383,7 +385,7 @@ sub posted_handler {
         }
     }
 
-    $vars->{LJ_cmtinfo} = LJ::js_dumper( \%LJ_cmtinfo );
+    $vars->{LJ_cmtinfo} = to_json( \%LJ_cmtinfo );
 
     return DW::Template->render_template( 'comments/posted.tt', $vars );
 }

--- a/cgi-bin/DW/Controller/Dev.pm
+++ b/cgi-bin/DW/Controller/Dev.pm
@@ -213,7 +213,7 @@ sub testhelper_json_handler {
         }
 
         if ( $args->{function} eq "js_dumper" ) {
-            $r->print( LJ::js_dumper($ret) );
+            $r->print( to_json($ret) );
         }
         elsif ( $args->{function} eq "json" ) {
             $r->print( to_json($ret) );

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -272,7 +272,7 @@ sub new_handler {
     $vars->{password_maxlength} = $LJ::PASSWORD_MAXLENGTH;
 
     $vars->{js_for_rte} = LJ::rte_js_vars();
-    $vars->{sitevalues} = LJ::js_dumper( \@sitevalues );
+    $vars->{sitevalues} = to_json( \@sitevalues );
 
     return DW::Template->render_template( 'entry/form.tt', $vars );
 }
@@ -647,7 +647,7 @@ sub _edit {
     };
 
     $vars->{js_for_rte} = LJ::rte_js_vars();
-    $vars->{sitevalues} = LJ::js_dumper( \@sitevalues );
+    $vars->{sitevalues} = to_json( \@sitevalues );
 
     return DW::Template->render_template( 'entry/form.tt', $vars );
 }

--- a/cgi-bin/LJ/Event/JournalNewComment.pm
+++ b/cgi-bin/LJ/Event/JournalNewComment.pm
@@ -15,6 +15,7 @@ package LJ::Event::JournalNewComment;
 use strict;
 use Scalar::Util qw(blessed);
 use LJ::Comment;
+use LJ::JSON;
 use DW::EmailPost::Comment;
 use Carp qw(croak);
 use base 'LJ::Event';
@@ -227,7 +228,7 @@ sub content {
 
     my $cmt_info = $comment->info;
     $cmt_info->{form_auth} = LJ::form_auth(1);
-    my $cmt_info_js = LJ::js_dumper($cmt_info) || '{}';
+    my $cmt_info_js = to_json($cmt_info) || '{}';
 
     my $posterusername = $self->comment->poster ? $self->comment->poster->{user} : "";
 
@@ -243,7 +244,7 @@ sub content {
 
     my $dtid_cmt_info = { u => $posterusername, rc => [] };
 
-    $ret .= "LJ_cmtinfo['$dtalkid'] = " . LJ::js_dumper($dtid_cmt_info) . "\n";
+    $ret .= "LJ_cmtinfo['$dtalkid'] = " . to_json($dtid_cmt_info) . "\n";
 
     $ret .= qq {
         </script>

--- a/cgi-bin/LJ/Event/JournalNewComment/Edited.pm
+++ b/cgi-bin/LJ/Event/JournalNewComment/Edited.pm
@@ -45,7 +45,7 @@ sub content {
 
     my $cmt_info = $comment->info;
     $cmt_info->{form_auth} = LJ::form_auth(1);
-    my $cmt_info_js = LJ::js_dumper($cmt_info) || '{}';
+    my $cmt_info_js = to_json($cmt_info) || '{}';
 
     my $posterusername = $self->comment->poster ? $self->comment->poster->{user} : "";
 
@@ -61,7 +61,7 @@ sub content {
 
     my $dtid_cmt_info = { u => $posterusername, rc => [] };
 
-    $ret .= "LJ_cmtinfo['$dtalkid'] = " . LJ::js_dumper($dtid_cmt_info) . "\n";
+    $ret .= "LJ_cmtinfo['$dtalkid'] = " . to_json($dtid_cmt_info) . "\n";
 
     $ret .= qq {
         </script>

--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -21,6 +21,7 @@ package LJ::S2;
 use DW;
 use lib DW->home . "/src/s2";
 use S2;
+use LJ::JSON;
 
 sub EntryPage {
     my ( $u, $remote, $opts ) = @_;
@@ -438,7 +439,7 @@ sub EntryPage {
 
         my $js =
             "<script>\n// don't crawl this.  read http://www.livejournal.com/developer/exporting\n";
-        $js .= "var LJ_cmtinfo = " . LJ::js_dumper($cmtinfo) . "\n";
+        $js .= "var LJ_cmtinfo = " . to_json($cmtinfo) . "\n";
         $js .= '</script>';
         $p->{'LJ_cmtinfo'} = $js if $opts->{'need_cmtinfo'};
         $p->{'head_content'} .= $js;

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -2880,7 +2880,6 @@ sub res_includes {
         );
 
         my $site_params     = to_json( \%site );
-        my $site_param_keys = to_json( [ keys %site ] );
 
         # include standard JS info
         $ret .= qq {

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -896,7 +896,7 @@ sub is_enabled {
         my $remote = LJ::get_remote();
         return 1 if $remote && $remote->can_beta_payments;
     }
-    return !LJ::conf_test( $LJ::DISABLED{$conf}, @_ );
+    return !LJ::conf_test( $LJ::DISABLED{$conf}, @_ ) + 0;
 }
 
 # document valid arguments for certain privs (using hooks)


### PR DESCRIPTION
CODE TOUR: This started with a support request and a mystery. The request was opened by a user who had renamed their journal to a username that was all numbers, starting with `0`, and then found they could no longer delete comments from their journal - they got a strange error when they tried. On investigation, this turned out be an issue ONLY with number-only usernames, and ONLY if they started with `0` - and only for comments in their own journal (they could comment in someone else's journal and those comments would behave normally). The reason for this turned out to be the unholy combination of 1) some really old code inherited from LJ and 2) the meeting of two different weakly-typed programming languages (Perl and Javascript).

In 2005, Brad wrote some Perl code to print Perl variables in a format Javascript understands. The code was a little janky, but in his defense this predates broader Perl support for doing this very thing. Unfortunately Perl doesn't really differentiate much between strings (ie, text) and numbers most of the time, and this code turned anything that was all numbers into a number. In printing out information about comments for JS, all-number usernames would end up as `{"journal": 007}` instead of `{"journal": "007"}`. This is exciting because, [per MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#numeric_literals), Javascript interprets numbers starting with `0` as octal number (if all digits that follow are under 8) or decimal number (in which case it strips the leading `0`s). This means that a journal named `042` would be converted to the octal number `34`, and then a check later on to see if we were acting in the correct journal to manage a comment would check if `34` was the same as `"042"` and fail, blocking the action on the comment. If it got converted to a decimal number, this check would succeed (because unless you're using strict equality, `7` and `"007"` are actually equal in JS), but the JS would then ask the server to act on a comment in journal `7` and the server would look and see that the comment was in journal `007` and go "Can't let you do that, buddy".

(without the starting `0`, swapping back and forth between number and string in Javascript repeatedly produces the same thing, which is why this didn't affect *all* journals with numerical usernames)

Interestingly, Livejournal actually [switched from using this code to using a more standard conversion function](https://github.com/apparentlymart/livejournal/commit/8e20f0a23a423421c79d9a5f9a830fa70c2dd4a3), though after the point at which the Dreamwidth codebase diverges from it. This fix does the same thing, though I then had to add some fixes in other places to keep numbers that should be printed as numbers and not strings in the correct form.

* Replace all instances of `LJ::js_dumper` with `to_json`
* Force `LJ::is_enabled` to return `1` or `0` so that printing to JSON receives the correct format.
* Update the handling of site vars in JS to use more modern JS that makes it clearer what the function is actually doing.