### PR TITLE
Fix some weirdness caused by Firefox reselecting on reload

### DIFF
--- a/htdocs/js/jquery.inbox.js
+++ b/htdocs/js/jquery.inbox.js
@@ -236,3 +236,9 @@ $("#inbox_messages").on("click", ".actions a", function(evt) {
 
     mark_items(null, 'mark_read', [qid]);
 });
+
+// Handle reloads where we have already-checked elements as some browsers will re-check them
+$(".item_checkbox:checked").each(function() {
+    $(this).parents('.inbox_item_row').addClass('selected-msg');
+});
+check_selected();


### PR DESCRIPTION
CODE TOUR: Firefox reselects previously-checked checkboxes when you reload a page, and it was causing some weirdness with the new inbox. This should behave a little bit better now.

