### PR TITLE
Hack old drafts functionality into new Create Entries page

### DIFF
--- a/htdocs/js/components/jquery.autocompletewithunknown.js
+++ b/htdocs/js/components/jquery.autocompletewithunknown.js
@@ -6,6 +6,7 @@
         });
 
         ele.val( tags_array.join(",") );
+        ele.trigger("change");
     }
 
     // this doesn't act on the autocompletewithunknown widget. Instead, it's called on our input field with autocompletion

--- a/htdocs/js/components/jquery.icon-select.js
+++ b/htdocs/js/components/jquery.icon-select.js
@@ -63,4 +63,7 @@ iconSelect.on("change", function(e) {
         }
     }
 });
+
+// in case other JS has modified the icon select HTML before we've loaded.
+iconSelect.trigger("change");
 });

--- a/htdocs/js/pages/entry/drafts.js
+++ b/htdocs/js/pages/entry/drafts.js
@@ -1,0 +1,161 @@
+/* ******************** DRAFT SUPPORT ******************** */
+
+  /* RULES:
+    -- don't save if they have typed in last 3 seconds, unless it's been
+       15 seconds.
+  */
+
+var LJDraft = {};
+
+LJDraft.saveInProg = false;
+LJDraft.maxTimeout = 15000; // Maximum length of time to go between saves, even if user is still typing
+LJDraft.inputDelay = 3000; // Input debounce delay, so we're not saving on each individual keypress
+LJDraft.savedMsg = "Autosaved at [[time]]";
+LJDraft.savedUnload = false; // Flag so we don't double-post when trying various methods of page unload saves.
+
+LJDraft.handleInput = function (evt) {
+    const date = Date.now();
+    if (LJDraft.saveTimeout == null) {
+        LJDraft.saveTimeout = date;
+    } else if (date - LJDraft.saveTimeout > LJDraft.maxTimeout) {
+        // Clear any existing delayed fuction call and save now
+        if (LJDraft.timer) {
+            clearTimeout(LJDraft.timer);
+        }
+        LJDraft.saveBody();
+        return;
+    }
+
+    clearTimeout(LJDraft.timer);
+    LJDraft.timer = setTimeout(() => {
+            LJDraft.saveBody();
+        }, LJDraft.inputDelay);
+
+}
+
+LJDraft.handleChange = function (evt) {
+    if (evt.target.id == "entry-body") {
+        LJDraft.saveBody();
+    } else {
+        LJDraft.saveProperties();
+    }
+}
+
+LJDraft.saveProperties = function () {
+    let newProps = {
+        saveEditor: $("#editor").val(),
+        saveSubject: $("#id-subject-0").val(),
+        saveTaglist: $("#js-taglist").val(),
+        saveMoodID: $("#js-current-mood").val(),
+        saveMood: $("#js-current-mood-other").val(),
+        saveLocation: $("#current-location").val(),
+        saveMusic: $("#current-music").val(),
+        saveAdultReason: $("#age_restriction_reason").val(),
+        saveCommentSet: $("#comment_settings").val(),
+        saveCommentScr: $("#opt_screening").val(),
+        saveAdultCnt: $("#age_restriction").val(),
+    }
+
+    if ( $("#prop_picture_keyword") ) { //In case the user has no userpics
+        newProps.saveUserpic = $("#prop_picture_keyword").val();
+    };
+
+    $.post("/__rpc_draft", newProps);
+
+};
+
+LJDraft.saveBody = function () {
+    // Clear our global save timeout
+    LJDraft.saveTimeout = null;
+    LJDraft.saveInProg = true;
+    let curBody;
+
+    if ($("#entry-body").css('display') == 'none') { // Need to check this to deal with hitting the back button
+        // Since they may start using the RTE in the middle of writing their
+        // entry, we should just get the editor each time.
+        if (! FCKeditorAPI) return;
+        var oEditor = FCKeditorAPI.GetInstance('entry-body');
+        if (oEditor.GetXHTML) {
+            curBody = oEditor.GetXHTML(true);
+            curBody = curBody.replace(/\n/g, '');
+        }
+    } else {
+        curBody = $("#entry-body").val();
+    }
+
+    $.post("/__rpc_draft", {"saveDraft": curBody}, function () {
+        let date = new Date();
+        let msg = LJDraft.savedMsg.replace(/\[\[time\]\]/, date.toLocaleTimeString('en-US', {timeStyle: "medium"}));
+        $("#draftstatus").text(msg + ' ');
+        LJDraft.saveInProg  = false;
+    });
+
+};
+
+function unloadSave() {
+    LJDraft.savedUnload = true;
+    LJDraft.saveBody();
+    LJDraft.saveProperties();
+}
+
+function initDraft(askToRestore) {
+    if (askToRestore && restoredDraft) {
+        if (confirm(confirmMsg)) {
+          // If the user wants to restore the draft, we place the
+          // values of their saved draft into the form.
+          $("#entry-body").val(restoredDraft);
+          $("#editor").val(restoredEditor);
+          $("#draftstatus").text(restoredMsg);
+          $("#id-subject-0").val(restoredSubject);
+          $("#js-taglist").val(restoredTaglist);
+          $("#js-current-mood").val(restoredMoodID);
+          $("#js-current-mood-other").val(restoredMood);
+          $("#current-location").val(restoredLocation);
+          $("#current-music").val(restoredMusic);
+          $("#age_restriction_reason").val(restoredAdultReason);
+          $("#comment_settings").val(restoredCommentSet);
+          $("#opt_screening").val(restoredCommentScr);
+          $("#age_restriction").val(restoredAdultCnt);
+            if ( $("#prop_picture_keyword") ) {
+              $("#prop_picture_keyword").val(restoredUserpic);
+              $("#prop_picture_keyword").trigger("change");
+          }
+        } else {
+            // Clear out their current draft
+            LJDraft.save('');
+            $.post("/__rpc_draft", {clearProperties: 1});
+        }
+   }
+
+    // set up event handlers
+    $("#content").on('change', '.draft', null, LJDraft.handleChange);
+    $("#content").on('input', 'textarea.draft', null, LJDraft.handleInput);
+
+    // Try to save draft when page is closed/hidden
+    document.onvisibilitychange = () => {
+      if (document.visibilityState === "hidden" && !LJDraft.savedUnload) {
+        unloadSave()
+      }
+    };
+
+    window.onpagehide = (event) => {
+      if (!LJDraft.savedUnload) {
+        unloadSave();
+      }
+    };
+}
+
+
+
+//LJDraft.maxTimeout = autoSaveInterval;
+LJDraft.savedMsg = savedMsg;
+
+if (should_init != null) {
+    initDraft(should_init);
+
+    // Hook into the RTE iframe once it's loaded, if we have draft support.
+function FCKeditor_OnComplete( editor ){ 
+        editor.EditorDocument.addEventListener('input', LJDraft.handleInput);
+};
+}
+

--- a/htdocs/js/pages/entry/drafts.js
+++ b/htdocs/js/pages/entry/drafts.js
@@ -27,7 +27,7 @@ LJDraft.handleInput = function (evt) {
     }
 
     clearTimeout(LJDraft.timer);
-    LJDraft.timer = setTimeout(() => {
+    LJDraft.timer = setTimeout(function () {
             LJDraft.saveBody();
         }, LJDraft.inputDelay);
 
@@ -54,7 +54,7 @@ LJDraft.saveProperties = function () {
         saveCommentSet: $("#comment_settings").val(),
         saveCommentScr: $("#opt_screening").val(),
         saveAdultCnt: $("#age_restriction").val(),
-    }
+    };
 
     if ( $("#prop_picture_keyword") ) { //In case the user has no userpics
         newProps.saveUserpic = $("#prop_picture_keyword").val();
@@ -116,7 +116,7 @@ function initDraft(askToRestore) {
           $("#comment_settings").val(restoredCommentSet);
           $("#opt_screening").val(restoredCommentScr);
           $("#age_restriction").val(restoredAdultCnt);
-            if ( $("#prop_picture_keyword") ) {
+          if ( $("#prop_picture_keyword") ) {
               $("#prop_picture_keyword").val(restoredUserpic);
               $("#prop_picture_keyword").trigger("change");
           }
@@ -128,17 +128,17 @@ function initDraft(askToRestore) {
    }
 
     // set up event handlers
-    $("#content").on('change', '.draft', null, LJDraft.handleChange);
-    $("#content").on('input', 'textarea.draft', null, LJDraft.handleInput);
+    $("#content").on('change', 'input.draft, textarea.draft', null, LJDraft.handleChange);
+    $("#content").on('input', '#entry-body', null, LJDraft.handleInput);
 
     // Try to save draft when page is closed/hidden
-    document.onvisibilitychange = () => {
+    document.onvisibilitychange = function(){
       if (document.visibilityState === "hidden" && !LJDraft.savedUnload) {
-        unloadSave()
+        unloadSave();
       }
     };
 
-    window.onpagehide = (event) => {
+    window.onpagehide = function (event) {
       if (!LJDraft.savedUnload) {
         unloadSave();
       }
@@ -154,8 +154,8 @@ if (should_init != null) {
     initDraft(should_init);
 
     // Hook into the RTE iframe once it's loaded, if we have draft support.
-function FCKeditor_OnComplete( editor ){ 
+    function FCKeditor_OnComplete( editor ){ 
         editor.EditorDocument.addEventListener('input', LJDraft.handleInput);
-};
+    };
 }
 

--- a/views/components/icon-select-dropdown.tt
+++ b/views/components/icon-select-dropdown.tt
@@ -12,6 +12,7 @@
           id = 'prop_picture_keyword',
           selected = current_icon_kw,
           items = icons,
+          class = class
       ) -%]
 
       [%- UNLESS omit_random_button -%]

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -56,6 +56,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
     "stc/fck/fckeditor.js"
     "js/pages/entry/rte.js"
 
+    # old drafts functionality
+    "js/pages/entry/drafts.js"
+
 ) -%]
 
 [% sections.title = action.edit ? dw.ml( '.title.edit' ) : dw.ml( '.title' ) %]
@@ -178,6 +181,7 @@ postFormInitData.strings = {
                         size = "50"
 
                         labelclass = "hidden"
+                        class = "draft"
 
                         placeholder = dw.ml(".subject.placeholder")
                 ) -%]
@@ -193,6 +197,7 @@ postFormInitData.strings = {
                   id = 'editor'
                   select = editors.selected
                   items = editors.items
+                  class = "draft"
                 ) -%]
 
                 <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1" target="_blank">[%-
@@ -218,9 +223,11 @@ postFormInitData.strings = {
                     wrap = "soft"
 
                     labelclass = "hidden"
+                    class = "draft"
 
                     placeholder = dw.ml(".event.placeholder")
                 ) -%]
+                <small id="draftstatus" type="text" disabled="disabled" name="draftstatus" role="status" aria-live="polite"></small>
             </div>
         </div></div>
 
@@ -413,4 +420,28 @@ postFormInitData.strings = {
             FCKLang.ReadMore = [% dw.ml('fcklang.readmore') | js %];
             FCKLang.CutContents = [% dw.ml('fcklang.cutcontents') | js %];
             FCKLang.LJCut = [% dw.ml('fcklang.ljcut') | js %];
+</script>
+
+<script>
+        // These JS variables contain the contents of the various draft fields.
+        var restoredDraft       = [% draft %];
+        var restoredEditor      = [% draft_properties.editor %] + '';
+        var restoredSubject     = [% draft_properties.subject %];
+        var restoredUserpic     = [% draft_properties.userpic %];
+        var restoredTaglist     = [% draft_properties.taglist %];
+        var restoredMoodID      = [% draft_properties.moodid %];
+        var restoredMood        = [% draft_properties.mood %];
+        var restoredLocation    = [% draft_properties.location1 %];
+        var restoredMusic       = [% draft_properties.music %];
+        var restoredAdultReason = [% draft_properties.adultreason %];
+        var restoredCommentSet  = [% draft_properties.commentset %];
+        var restoredCommentScr  = [% draft_properties.commentscr %];
+        var restoredAdultCnt    = [% draft_properties.adultcnt %];
+
+        var autoSaveInterval = [% autosave_interval %];
+        var savedMsg = [% dw.ml('.draft.autosave', {time => '[[time]]'}) | js %];
+        var restoredMsg = [% dw.ml('.draft.restored') | js %]
+        var confirmMsg = [% dw.ml( '.draft.confirm2', { subjectline => draft_subject_raw } ) | js %]
+
+        var should_init = [%init_draft %];
 </script>

--- a/views/entry/form.tt.text
+++ b/views/entry/form.tt.text
@@ -13,6 +13,14 @@
 
 .button.post.quick=Post
 
+.draft.autosave=Autosaved draft at [[time]]
+
+.draft.confirm=Restore from saved draft?
+
+.draft.confirm2=Restore from saved draft entitled [[subjectline]]?
+
+.draft.restored=Restored last saved draft
+
 .error.cantpost=Sorry: you can't post at this time.
 
 .error.disabled=You can't post because of the type of account you have.

--- a/views/entry/module-age_restriction.tt
+++ b/views/entry/module-age_restriction.tt
@@ -33,6 +33,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.select( label = dw.ml( ".label.age_restriction" )
             name = "age_restriction"
             id = "age_restriction"
+            class = "draft"
 
             items = levelselect
         ) -%]
@@ -42,6 +43,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.textbox( label = dw.ml( ".label.age_restriction_reason" )
             name = "age_restriction_reason"
             id = "age_restriction_reason"
+            class = "draft"
 
             size = "20"
             maxlength = "255"

--- a/views/entry/module-comments.tt
+++ b/views/entry/module-comments.tt
@@ -21,6 +21,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.select( label = "Comments:"
             name = "comment_settings"
             id = "comment_settings"
+            class = "draft"
 
             items = [
                 ""              "Journal Default"
@@ -34,6 +35,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.select( label = "Screening:"
             name = "opt_screening"
             id = "opt_screening"
+            class = "draft"
 
             items = [
                 ""      "Journal Default"

--- a/views/entry/module-currents.tt
+++ b/views/entry/module-currents.tt
@@ -24,6 +24,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.select( label = dw.ml( ".label.current_mood" )
             name = "current_mood"
             id = "js-current-mood"
+            class = "draft"
 
             items = moodselect
         ) -%]
@@ -33,6 +34,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.textbox( label = dw.ml( ".label.current_mood_other" )
           name = "current_mood_other"
           id = "js-current-mood-other"
+          class = "draft"
 
           size = "20"
           maxlength = "30"
@@ -43,6 +45,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.textbox( label = dw.ml( ".label.current_music" )
             name = "current_music"
             id = "current-music"
+            class = "draft"
 
             size="20"
             maxlength="80"
@@ -53,6 +56,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.textbox( label = dw.ml( ".label.current_location" )
             name = "current_location"
             id = "current-location"
+            class = "draft"
 
             size = "20"
             maxlength = "80"

--- a/views/entry/module-icons.tt
+++ b/views/entry/module-icons.tt
@@ -24,7 +24,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     </div>
     <div class="row">
         <div class="columns">
-            [% INCLUDE "components/icon-select-dropdown.tt" omit_random_button = 1 %]
+            [% INCLUDE "components/icon-select-dropdown.tt" omit_random_button = 1 class = "draft" %]
         </div>
     </div>
 

--- a/views/entry/module-tags.tt
+++ b/views/entry/module-tags.tt
@@ -20,6 +20,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.textarea( label = dw.ml(".label.tags")
             name = "taglist"
             id = "js-taglist"
+            class = "draft"
 
             cols = "20"
             rows = "1"


### PR DESCRIPTION
CODE TOUR: One of the things missing from the new Create Entries page was any sort of draft functionality. On the old page, this basically auto-saved in-progress entries, and then if you had a draft saved, when you opened the post editor again, it would ask if you'd like to restore from the previous draft. This adds that functionality to the new page, with some updates on the JS that powers it that will hopefully make the save behavior more reliable.