### PR TITLE
Strip links from the userbio for accounts that aren't validated yet

### DIFF
--- a/cgi-bin/DW/Logic/ProfilePage.pm
+++ b/cgi-bin/DW/Logic/ProfilePage.pm
@@ -715,7 +715,7 @@ sub bio {
             $ret =~ s!\n!<br />!g;
         }
         else {
-            LJ::CleanHTML::clean_userbio( \$ret );
+            LJ::CleanHTML::clean_userbio( \$ret, !$u->is_validated );
         }
 
         LJ::EmbedModule->expand_entry( $u, \$ret );

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1826,7 +1826,7 @@ sub clean_comment {
 }
 
 sub clean_userbio {
-    my $ref = shift;
+    my ( $ref, $strip_links ) = @_;
     return undef unless ref $ref;
 
     clean(
@@ -1842,8 +1842,10 @@ sub clean_userbio {
 
             # Bios are always local, but for now, we are marking them as
             # HTML so that people don't have to reformat everything.
-            formatting  => 'html',
-            at_mentions => 1,
+            formatting   => 'html',
+            at_mentions  => 1,
+            noautolinks  => $strip_links,
+            extractlinks => $strip_links,
         }
     );
 }


### PR DESCRIPTION
CODE TOUR: Part of the endless war on spam - this delinkifies links in the bios of users who haven't validated their email addresses yet, making it slower for spammers to create a bunch of profiles and dump spam links in them (if they aren't actual links, it doesn't count towards page rank algorithms on Google etc)

