### PR TITLE
Add spam domain auto-suspend list

### DIFF
--- a/cgi-bin/DW/Controller/EditIcons.pm
+++ b/cgi-bin/DW/Controller/EditIcons.pm
@@ -74,6 +74,8 @@ sub editicons_handler {
         my $post = $r->post_args;
         return error_ml("error.utf8") unless LJ::text_in($post);
 
+        LJ::Hooks::run_hooks( 'spam_check', $u, $post, 'icons' );
+
         ### save changes to existing pics
         if ( $post->{'action:save'} ) {
 
@@ -111,6 +113,7 @@ sub editicons_handler {
 
                 # parse the post parameters into an array of new pics
                 @uploaded_userpics = parse_post_uploads( $post, $u, $MAX_UPLOAD );
+                LJ::Hooks::run_hooks( 'spam_check', $u, $post, 'icons' );
             }
 
             # if we're (c) coming from the factory, then we don't

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -234,6 +234,9 @@ sub new_handler {
             my $form_req = {};
             _form_to_backend( $form_req, $post, errors => $errors );
 
+            # check for spam domains
+            LJ::Hooks::run_hooks( 'spam_check', $auth{poster}, $form_req, 'entry' );
+
             # if we didn't have any errors with decoding the form, proceed to post
             unless ( $errors->exist ) {
                 my %post_res = _do_post( $form_req, $flags, \%auth, warnings => $warnings );
@@ -535,6 +538,9 @@ sub _edit {
                 allow_empty => $mode_delete,
                 errors      => $errors
             );
+
+            # check for spam domains
+            LJ::Hooks::run_hooks( 'spam_check', $remote, $form_req, 'entry' );
 
             # if we didn't have any errors with decoding the form, proceed to post
             unless ( $errors->exist ) {
@@ -1450,6 +1456,9 @@ sub preview_handler {
 
     my $form_req = {};
     _form_to_backend( $form_req, $post );
+
+    # check for spam domains
+    LJ::Hooks::run_hooks( 'spam_check', $up, $form_req, 'entry' );
 
     my ( $event, $subject ) = ( $form_req->{event}, $form_req->{subject} );
     LJ::CleanHTML::clean_subject( \$subject );

--- a/cgi-bin/DW/Controller/Talk.pm
+++ b/cgi-bin/DW/Controller/Talk.pm
@@ -457,6 +457,9 @@ sub talkpost_do_handler {
     my $wasscreened = ( $parent->{state} eq 'S' );
     my $talkid;
 
+    # check for spam domains
+    LJ::Hooks::run_hooks( 'spam_check', $comment->{u}, $comment, 'comment' );
+
     if ($editid) {
         my ( $postok, $talkid_or_err ) = LJ::Talk::Post::edit_comment($comment);
         unless ($postok) {

--- a/cgi-bin/DW/Hooks/SpamCheck.pm
+++ b/cgi-bin/DW/Hooks/SpamCheck.pm
@@ -30,7 +30,7 @@ LJ::Hooks::register_hook(
         my ( $user, $data, $location ) = @_;
         return unless defined $user && defined $data && defined $location;
         my $system = LJ::load_user('system');
-        my $blocked_links = [ 'google.com', 'yahoo.com' ];
+        my @blocked_links = grep { $_ } split( /\r?\n/, LJ::load_include('spamblocklist') );
         my $suspended     = 0;
         my $location_str  = $location; # same for everything but hashrefs
 
@@ -38,7 +38,7 @@ LJ::Hooks::register_hook(
             my $item = shift;
             return unless defined $item;    # don't waste time iterating over undefined items
 
-            foreach my $re (@$blocked_links) {
+            foreach my $re (@blocked_links) {
                 if ( $item =~ $re ) {
                     LJ::User::set_suspended( $user, $system,
                         "auto-suspend for matching domain blocklist: $re in $location_str" );

--- a/cgi-bin/DW/Hooks/SpamCheck.pm
+++ b/cgi-bin/DW/Hooks/SpamCheck.pm
@@ -29,6 +29,7 @@ LJ::Hooks::register_hook(
     sub {
         my ( $user, $data, $location ) = @_;
         return unless defined $user && defined $data && defined $location;
+        my $system = LJ::load_user('system');
         my $blocked_links = [ 'google.com', 'yahoo.com' ];
         my $suspended     = 0;
         my $location_str  = $location; # same for everything but hashrefs
@@ -39,7 +40,7 @@ LJ::Hooks::register_hook(
 
             foreach my $re (@$blocked_links) {
                 if ( $item =~ $re ) {
-                    LJ::User::set_suspended( $user, 'blocklistmatch',
+                    LJ::User::set_suspended( $user, $system,
                         "auto-suspend for matching domain blocklist: $re in $location_str" );
                     $suspended = 1;
                     last;

--- a/cgi-bin/DW/Hooks/SpamCheck.pm
+++ b/cgi-bin/DW/Hooks/SpamCheck.pm
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+#
+# DW::Hooks::SpamCheck
+#
+# This module implements a hook for checking input for blocked domains, and
+# auto-suspending a user if one is found.
+#
+# Authors:
+#      Momiji <momijizukamori@gmail.com>
+#
+# Copyright (c) 2023 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::Hooks::SpamCheck;
+
+use strict;
+use warnings;
+use Scalar::Util qw/reftype/;
+
+use LJ::Hooks;
+use LJ::MemCache;
+
+LJ::Hooks::register_hook(
+    'spam_check',
+    sub {
+        my ( $user, $data, $location ) = @_;
+        return unless defined $user && defined $data && defined $location;
+        my $blocked_links = [ 'google.com', 'yahoo.com' ];
+        my $suspended     = 0;
+        my $location_str  = $location; # same for everything but hashrefs
+
+        my $check_item = sub {
+            my $item = shift;
+            return unless defined $item;    # don't waste time iterating over undefined items
+
+            foreach my $re (@$blocked_links) {
+                if ( $item =~ $re ) {
+                    LJ::User::set_suspended( $user, 'blocklistmatch',
+                        "auto-suspend for matching domain blocklist: $re in $location_str" );
+                    $suspended = 1;
+                    last;
+                }
+            }
+        };
+
+        if ( reftype $data eq reftype [] ) {
+            foreach my $item (@$data) {
+                $check_item->($item);
+                last if $suspended;
+            }
+        }
+        elsif ( reftype $data eq reftype {} ) {
+            foreach my $key ( keys %$data ) {
+                $location_str = "$key of $location";
+                $check_item->( $data->{$key} );
+                last if $suspended;
+            }
+        }
+        else {
+            $check_item->($data);
+        }
+
+    }
+);
+
+1;

--- a/htdocs/editjournal.bml
+++ b/htdocs/editjournal.bml
@@ -254,6 +254,9 @@ body<=
                         });
                 }
 
+                # check for spam domains
+                LJ::Hooks::run_hooks('spam_check', $u, \%req, 'entry');
+
                 # do editevent request
                 LJ::do_request(\%req, \%res, { 'noauth' => 1, 'u' => $u });
 

--- a/htdocs/manage/profile/index.bml
+++ b/htdocs/manage/profile/index.bml
@@ -734,6 +734,7 @@ body<=
         }
 
         LJ::Hooks::run_hooks('profile_save', $u, \%saved, \%POST);
+        LJ::Hooks::run_hooks('spam_check', $u, \%saved, 'userbio');
         LJ::Hooks::run_hook('set_profile_settings_extra', $u, \%POST);
 
         # tell the user all is well

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -362,7 +362,7 @@ _c?>
         LJ::do_request(\%req, \%res, $flags);
 
         # check for spam domains
-        LJ::Hooks::run_hooks('spam_check', $user, \%req, 'entry');
+        LJ::Hooks::run_hooks('spam_check', $u, \%req, 'entry');
 
         if (!$errors) {
             # examine response

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -361,6 +361,9 @@ _c?>
         my %res;
         LJ::do_request(\%req, \%res, $flags);
 
+        # check for spam domains
+        LJ::Hooks::run_hooks('spam_check', $user, \%req, 'entry');
+
         if (!$errors) {
             # examine response
             my $protocol_message;


### PR DESCRIPTION
CODE TOUR: A number of our spammers are repeat customers. This change allows site admins to set up a list of domains that posting links to will cause your account to get auto-suspended, with a note in the admin log of what domain got flagged and where it got flagged.

This should check all field of entries, all fields of userbios, all fields of comments, and all fields of icons. Suspends will be from the `system` user. Fixes #3080 