### PR TITLE
Only iterate over array elements, not the entire array object's props

### DIFF
--- a/htdocs/js/pages/entry/new.js
+++ b/htdocs/js/pages/entry/new.js
@@ -215,15 +215,16 @@ var postForm = (function($) {
             $.when.apply($, requests).done(function() {
                 var members_data_list = "";
                 members_data.sort();
-                for (member in members_data) {
-                    members_data_list = members_data_list + "<li>" + members_data[member] + "</li>";
-                }
+                members_data.forEach(function(member) {
+                    members_data_list = members_data_list + "<li>" + member + "</li>";
+                });
+                
                 $custom_access_group_members.html(members_data_list);
             });
         }
 
         function saveCurrentGroups() {
-            $custom_groups.data( "original_data", $custom_groups.find("input[name=custom_bit]").serializeArray() );
+           $custom_groups.data( "original_data", $custom_groups.find("input[name=custom_bit]").serializeArray() );
         }
 
         function onOpen() {


### PR DESCRIPTION
CODE TOUR: Javascript is cursed, our codebase is haunted, and the combination of the two meant the new entry page was cheerfully printing a bunch of Javascript functions into the Custom Access Filter modal. The codebase is -1 point haunted and now does not do that. (The slightly longer version: `array.forEach()` and `for(i in array)` behave the same way if and only if nothing is patching new functions onto the Array prototype)