### PR TITLE
Add substack username handling

### DIFF
--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -100,7 +100,7 @@ $domaintosite{"instagram.com"} =
 $domaintosite{"del.icio.us"} =
     DW::External::Site->new( "30", "del.icio.us", "del.icio.us", "Delicious", "delicious" );
 $domaintosite{"substack.com"} =
-    DW::External::Site->new( "31", "www.substack.com", "substack.com", "Substack", "substack");
+    DW::External::Site->new( "31", "substack.com", "substack.com", "Substack", "substack");
 
 @all_sites_without_alias = values %domaintosite;
 

--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -99,6 +99,8 @@ $domaintosite{"instagram.com"} =
     DW::External::Site->new( "29", "www.instagram.com", "instagram.com", "Instagram", "instagram" );
 $domaintosite{"del.icio.us"} =
     DW::External::Site->new( "30", "del.icio.us", "del.icio.us", "Delicious", "delicious" );
+$domaintosite{"substack.com"} =
+    DW::External::Site->new( "31", "www.substack.com", "substack.com", "Substack", "substack");
 
 @all_sites_without_alias = values %domaintosite;
 
@@ -145,6 +147,7 @@ $domaintosite{"facebook"}        = $domaintosite{"facebook.com"};
 $domaintosite{"fb"}              = $domaintosite{"facebook.com"};
 $domaintosite{"instagram"}       = $domaintosite{"instagram.com"};
 $domaintosite{"ig"}              = $domaintosite{"instagram.com"};
+$domaintosite{"substack"}        = $domaintosite{"substack.com"};
 
 foreach my $value (@all_sites_without_alias) {
     $idtosite{ $value->{siteid} } = $value;

--- a/cgi-bin/DW/External/Site/Substack.pm
+++ b/cgi-bin/DW/External/Site/Substack.pm
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+#
+# DW::External::Site::Substack
+#
+# Class to support Substack linking.
+#
+# Authors:
+#      Carly Ho <https://veryroundbird.dreamwidth.org>
+#
+# Copyright (c) 2011/2023 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::External::Site::Substack;
+
+use strict;
+use base 'DW::External::Site';
+use Carp qw/ croak /;
+
+# new does nothing for these classes
+sub new { croak 'cannot build with new'; }
+
+# returns an object if we allow this domain; else undef
+sub accepts {
+    my ( $class, $parts ) = @_;
+
+    # let's just assume the last two parts are good if we have them
+    return undef unless scalar(@$parts) >= 2;
+
+    return bless { hostname => "$parts->[-2].$parts->[-1]" }, $class;
+}
+
+# argument: DW::External::User
+# returns URL to this account
+sub journal_url {
+    my ( $self, $u ) = @_;
+    croak 'need a DW::External::User'
+        unless $u && ref $u eq 'DW::External::User';
+
+    return 'http://' . $u->user . '.' . $self->{hostname} . '/';
+}
+
+# argument: DW::External::User
+# links to the about page
+sub profile_url {
+    my ( $self, $u ) = @_;
+    croak 'need a DW::External::User'
+        unless $u && ref $u eq 'DW::External::User';
+
+    return 'http://' . $u->user . '.' . $self->{hostname} . '/about';
+}
+
+# argument: DW::External::User
+# returns info for the badge image (userhead icon) for this user
+sub badge_image {
+    my ( $self, $u ) = @_;
+    croak 'need a DW::External::User'
+        unless $u && ref $u eq 'DW::External::User';
+
+    return {
+        url    => "https://substackcdn.com/icons/substack/favicon.ico",
+        width  => 16,
+        height => 16,
+    };
+}
+
+1;


### PR DESCRIPTION
CODE TOUR: Adds custom username linking with userhead for Substack accounts so everyone can subscribe to your newsletter.

Addresses #3055