### PR TITLE
Add Bilibili and Rumble to embeds whitelist and fix CriticalCommons embeds

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -106,7 +106,7 @@ my %host_path_match = (
     "www.msnbc.com"    => [ qr!^/msnbc/embedded-video/\w+!, 1 ],
     "my.mail.ru"       => [ qr!^/video/embed/\d+!,          1 ],
 
-    "nekocap.com"      => [ qr!^/view/[a-zA-Z0-9]+?embed=true!,       1 ],
+    "nekocap.com"      => [ qr!^/view/[a-zA-Z0-9]+\?embed=true!,       1 ],
     "ext.nicovideo.jp" => [ qr!^/thumb/!,                             0 ],
     "noisetrade.com"   => [ qr!^/service/widgetv2/!,                  1 ],
     "www.npr.org"      => [ qr!^/templates/event/embeddedVideo\.php!, 1 ],

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -106,6 +106,7 @@ my %host_path_match = (
     "www.msnbc.com"    => [ qr!^/msnbc/embedded-video/\w+!, 1 ],
     "my.mail.ru"       => [ qr!^/video/embed/\d+!,          1 ],
 
+    "nekocap.com"      => [ qr!^/view/[a-zA-Z0-9]+?embed=true!,       1 ],
     "ext.nicovideo.jp" => [ qr!^/thumb/!,                             0 ],
     "noisetrade.com"   => [ qr!^/service/widgetv2/!,                  1 ],
     "www.npr.org"      => [ qr!^/templates/event/embeddedVideo\.php!, 1 ],

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -57,6 +57,7 @@ my %host_path_match = (
     "audiomack.com" => [ qr!^/embed/!, 1 ],
 
     "bandcamp.com"                => [ qr!^/EmbeddedPlayer/!, 1 ],
+    "player.bilibili.com"         => [ qr!^/player.html!,     1 ],
     "blip.tv"                     => [ qr!^/play/!,           1 ],
     "percolate.blogtalkradio.com" => [ qr!^/offsiteplayer$!,  1 ],
     "app.box.com"                 => [ qr!^/embed/s/!,        1 ],

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -106,7 +106,7 @@ my %host_path_match = (
     "www.msnbc.com"    => [ qr!^/msnbc/embedded-video/\w+!, 1 ],
     "my.mail.ru"       => [ qr!^/video/embed/\d+!,          1 ],
 
-    "nekocap.com"      => [ qr!^/view/[a-zA-Z0-9]+\?embed=true!,       1 ],
+    "nekocap.com"      => [ qr!^/view/[a-zA-Z0-9]+!,       1 ],
     "ext.nicovideo.jp" => [ qr!^/thumb/!,                             0 ],
     "noisetrade.com"   => [ qr!^/service/widgetv2/!,                  1 ],
     "www.npr.org"      => [ qr!^/templates/event/embeddedVideo\.php!, 1 ],

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -106,7 +106,6 @@ my %host_path_match = (
     "www.msnbc.com"    => [ qr!^/msnbc/embedded-video/\w+!, 1 ],
     "my.mail.ru"       => [ qr!^/video/embed/\d+!,          1 ],
 
-    "nekocap.com"      => [ qr!^/view/[a-zA-Z0-9]+!,       1 ],
     "ext.nicovideo.jp" => [ qr!^/thumb/!,                             0 ],
     "noisetrade.com"   => [ qr!^/service/widgetv2/!,                  1 ],
     "www.npr.org"      => [ qr!^/templates/event/embeddedVideo\.php!, 1 ],

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -65,7 +65,7 @@ my %host_path_match = (
     "chirb.it"                => [ qr!^/wp/!,             1 ],
     "codepen.io"              => [ qr!^/enxaneta/embed/!, 1 ],
     "coub.com"                => [ qr!^/embed/!,          1 ],
-    "www.criticalcommons.org" => [ qr!/embed_view$!,      0 ],
+    "www.criticalcommons.org" => [ qr!/embed$!,      0 ],
 
     "www.dailymotion.com" => [ qr!^/embed/video/!,                   1 ],
     "diode.zone"          => [ qr!^/videos/embed/[0-9a-fA-F\-]{36}!, 1 ],

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -120,6 +120,7 @@ my %host_path_match = (
     "www.random.org"       => [ qr!^/widgets/integers/iframe.php$!,        1 ],
     "www.redditmedia.com"  => [ qr!^/r/\w+/comments/\w+/\w+/$!,            1 ],
     "www.reverbnation.com" => [ qr!^/widget_code/html_widget/artist_\d+$!, 1 ],
+    "rumble.com"           => [ qr!^/embed/[a-zA-Z0-9]+/!                , 1 ],
 
     "www.sbs.com.au" => [ qr!/player/embed/!, 0 ]
     ,    # best guess; language parameter before /player may vary

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 108;
+use Test::More tests => 110;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -90,6 +90,7 @@ note("misc");
 "http://bandcamp.com/EmbeddedPlayer/v=2/track=123123123/size=venti/bgcol=FFFFFF/linkcol=4285BB/"
     );
     test_good_url("http://bandcamp.com/EmbeddedPlayer/v=2/track=123123123");
+    test_good_url("https://player.bilibili.com/player.html?aid=593134119&bvid=BV1Dq4y1y7Zj&cid=483765371&page=1");
     test_good_url("http://blip.tv/play/x11Xx11Xx.html");
     test_good_url(
         "https://percolate.blogtalkradio.com/offsiteplayer?hostId=123456&episodeId=12345678");
@@ -99,9 +100,7 @@ note("misc");
     test_good_url("https://chirb.it/wp/pnC9Kh");
     test_good_url("//codepen.io/enxaneta/embed/gPeZdP/?height=268&theme-id=0&default-tab=result");
     test_good_url("http://coub.com/embed/x1xx2xxxxxX");
-    test_good_url(
-"http://www.criticalcommons.org/Members/china_shop/clips/handle-with-care-white-collar-fanvid/embed_view"
-    );
+    test_good_url("https://criticalcommons.org/embed?m=XycozAvcH");
 
     # D
     test_good_url("http://www.dailymotion.com/embed/video/x1xx11x");
@@ -220,6 +219,7 @@ note("misc");
     test_good_url(
 "https://www.reverbnation.com/widget_code/html_widget/artist_299962?widget_id=55&pwc[song_ids]=4189683&context_type=song&pwc[size]=small&pwc[color]=dark"
     );
+    test_good_url("https://rumble.com/embed/vr722g/?pub=4");
 
     # S
     test_good_url("http://www.sbs.com.au/yourlanguage//player/embed/id/163111");


### PR DESCRIPTION
CODE TOUR: Videos from Bilibili and Rumble are now embeddable on the site; CriticalCommons embedding should now be fixed.

Addresses #2942, #2915, and #2657.