### PR TITLE
stop suspending yourself, stop suspending yourself

### DIFF
--- a/cgi-bin/LJ/Console/Command.pm
+++ b/cgi-bin/LJ/Console/Command.pm
@@ -125,7 +125,7 @@ sub execute_safely {
             if $cmd->requires_remote && !$remote;
 
         return $cmd->error("Your account status prevents you from using the console.")
-            if $cmd->requires_remote && !$remote->is_visible;
+            if $cmd->requires_remote && $remote->is_inactive && !$remote->has_priv("suspend");
 
         return $cmd->error("You are not authorized to run this command.")
             unless $cmd->can_execute;


### PR DESCRIPTION
@rahaeli says this is the line of code that prevents an admin from reversing their own suspension if they accidentally suspend themselves. (Which with the amount of spam accounts we've been dealing with lately, is not that hard to do.)

It prevents any console command from being executed by a user who doesn't have a statusvis of V.

There are a LOT of other statusvis codes! Looking at the available helper methods, `is_inactive` seems like the right one to use. It encompasses the S (suspended), D (deleted), and X (expunged) codes. But it still needs to be overridden.

So: don't allow a deleted/suspended/purged user to run a console command... unless that user has the suspend priv.

Fixes #3111.