### PR TITLE
add me.com and fastmail.com to the list of common email domains

### DIFF
--- a/cgi-bin/LJ/User/Message.pm
+++ b/cgi-bin/LJ/User/Message.pm
@@ -545,7 +545,8 @@ sub check_email {
     my $tf_domain      = Text::Fuzzy->new( $domain, max => 3, trans => 1 );
     my @common_domains = (
         'gmail.com', 'yahoo.com', 'hotmail.com', 'outlook.com',
-        'aol.com',   'live.com',  'mail.com',    'ymail.com'
+        'aol.com',   'live.com',  'mail.com',    'fastmail.com',
+        'ymail.com', 'me.com'
     );
     my $nearest      = $tf_domain->nearest( \@common_domains );
     my $bad_spelling = defined $nearest && $tf_domain->last_distance > 0;


### PR DESCRIPTION
Users with email addresses at these common domains complained about having to confirm they had not misspelled a similar domain. Add these two to the list so that they are no longer flagged as possible misspellings.

Fixes #2906. Fixes #3118.