### PR TITLE
fix failing t/media-security.t

### DIFF
--- a/cgi-bin/DW/Media/Base.pm
+++ b/cgi-bin/DW/Media/Base.pm
@@ -137,7 +137,8 @@ sub visible_to {
     return 0 unless LJ::isu($other_u);
 
     # private check.  if it's us or an admin, allow, else fail.
-    my $refer       = { DW::Request->get->headers_in }->{Referer};
+    my %headers     = defined DW::Request->get ? DW::Request->get->headers_in : ();
+    my $refer       = $headers{Referer};
     my $is_sitepage = ( defined $refer && $refer eq "$LJ::SITEROOT/" ) ? 1 : 0;
     return 1 if $is_sitepage && $other_u->has_priv( 'canview', 'images' );
 


### PR DESCRIPTION
A line I added in #3100 was failing in testing because there was no web request object defined in that context. This was the error:

`Can't call method "headers_in" on an undefined value at dw/cgi-bin/DW/Media/Base.pm line 140.`

This adds an undefined value check to make sure everything proceeds smoothly.

CODE TOUR: No visible impact, this only affects automated code tests.