### PR TITLE
Allow email spell-checking to be overridden in admin/sysban

### DIFF
--- a/views/admin/sysban/addnew.tt
+++ b/views/admin/sysban/addnew.tt
@@ -40,7 +40,7 @@
 
   <div id="spelling" style="[% spellstyle %]">
 
-[% form.checkbox( label = dw.ml( '.label.spelling' ), value = 0,
+[% form.checkbox( label = dw.ml( '.label.spelling' ), value = 1,
                   name = "force_spelling", id = "force_spelling" ) %]
   </div>
 


### PR DESCRIPTION
I have no idea why this was 0 instead of 1 in the first place.

Fixes #2910.

CODE TOUR: This fixes a BML conversion error that was preventing the "don't spell-check this email" checkbox from doing its job.