### PR TITLE
better handling of sphinx failure in SiteSearch hooks

### DIFF
--- a/cgi-bin/DW/Hooks/SiteSearch.pm
+++ b/cgi-bin/DW/Hooks/SiteSearch.pm
@@ -18,13 +18,14 @@ package DW::Hooks::SiteSearch;
 
 use strict;
 use LJ::Hooks;
+use Carp;
 
 sub _sphinx_db {
 
     # ensure we can talk to our system
     return unless @LJ::SPHINX_SEARCHD;
     my $dbh = LJ::get_dbh('sphinx_search')
-        or die "Unable to get sphinx_search database handle.\n";
+        or carp "Unable to get sphinx_search database handle.";
     return $dbh;
 }
 

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -505,11 +505,6 @@ sub set_suspended {
 
     LJ::Hooks::run_hooks( "account_cancel", $u );
 
-    if ( my $err = LJ::Hooks::run_hook( "cdn_purge_userpics", $u ) ) {
-        $$errref = $err if ref $errref and $err;
-        return 0;
-    }
-
     return $res;    # success
 }
 


### PR DESCRIPTION
CODE TOUR: Stop printing `Unable to get sphinx_search database handle` in the console when suspending or unsuspending a user while site search is down.

This changes the `die` to a `carp` so that the warning goes to the error log and the command that called the hook is allowed to resume execution.

Additionally, this makes it more obvious that the hook is the last thing called when suspending, by removing a call to a different hook that was undefined.

Fixes #2909.