### PR TITLE
fix typos in shortcut setting strings

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1710,6 +1710,9 @@ general setting.contentpromotion.option
 
 general setting.prod.display.title
 
+general setting.shortcuts.des
+general setting.shortcuts_touch.des
+
 general settings.settingprod.intro
 general settings.settingprod.outro
 general settings.settingprod.update

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2960,7 +2960,7 @@ setting.searchinclusion.option.comm=Attempt to block outside search engines from
 
 setting.searchinclusion.option.self=Attempt to block outside search engines from indexing my journal
 
-setting.shortcuts.des=Enables keyboard shorcuts.
+setting.shortcuts.desc=Enables keyboard shortcuts.
 
 setting.shortcuts.label=Keyboard shortcuts
 
@@ -2972,7 +2972,7 @@ setting.shortcuts.prev.des=Previous entry/top-level comment
 
 setting.shortcuts.prev.label=Previous
 
-setting.shortcuts_touch.des=Enables touch shorcuts.
+setting.shortcuts_touch.desc=Enables touch shortcuts.
 
 setting.shortcuts_touch.label=Touch shortcuts
 

--- a/cgi-bin/DW/Setting/Shortcuts.pm
+++ b/cgi-bin/DW/Setting/Shortcuts.pm
@@ -50,7 +50,7 @@ sub option {
 sub des {
     my $class = $_[0];
 
-    return $class->ml('setting.shortcuts.des');
+    return $class->ml('setting.shortcuts.desc');
 }
 
 1;

--- a/cgi-bin/DW/Setting/ShortcutsTouch.pm
+++ b/cgi-bin/DW/Setting/ShortcutsTouch.pm
@@ -50,7 +50,7 @@ sub option {
 sub des {
     my $class = $_[0];
 
-    return $class->ml('setting.shortcuts_touch.des');
+    return $class->ml('setting.shortcuts_touch.desc');
 }
 
 1;


### PR DESCRIPTION
I was tempted to rename the keys with 'shorcuts' but I'm not actually that much of a troll. I changed .des to .desc instead.

Fixes #2891.

CODE TOUR: Change 'shorcuts' to 'shortcuts' in two places.