### PR TITLE
new template constants for username and password max lengths

### DIFF
--- a/cgi-bin/DW/Controller/Admin/Invites.pm
+++ b/cgi-bin/DW/Controller/Admin/Invites.pm
@@ -307,8 +307,6 @@ sub promo_controller {
 
     $vars->{mysql_date} = sub { $_[0] ? LJ::mysql_date( $_[0] ) : "" };
 
-    $vars->{maxlength_user} = $LJ::USERNAME_MAXLENGTH;
-
     if ( $r->did_post ) {
 
         $vars->{code}  = $r->post_args->{code} || "";

--- a/cgi-bin/DW/Controller/Admin/Priv.pm
+++ b/cgi-bin/DW/Controller/Admin/Priv.pm
@@ -75,8 +75,6 @@ sub main_controller {
         $vars->{map_codeid}->{ $_->{privcode} } = $_->{prlid};
     }
 
-    $vars->{maxlength_user} = $LJ::USERNAME_MAXLENGTH;
-
     my $mode = $form_args->{mode};
 
     $mode ||= "viewpriv" if $form_args->{priv};

--- a/cgi-bin/DW/Controller/Admin/SpamReports.pm
+++ b/cgi-bin/DW/Controller/Admin/SpamReports.pm
@@ -397,8 +397,6 @@ sub main_controller {
         $rv->{useronly} = sub { "spamreports?mode=${_[0]}_u" };
         $rv->{anononly} = sub { "spamreports?mode=${_[0]}_a" };
 
-        $rv->{maxlength_user} = $LJ::USERNAME_MAXLENGTH;
-
         return DW::Template->render_template( 'admin/spamreports/index.tt', $rv );
     }
 }

--- a/cgi-bin/DW/Controller/Admin/UserHistory.pm
+++ b/cgi-bin/DW/Controller/Admin/UserHistory.pm
@@ -57,8 +57,6 @@ sub statushistory_controller {
     my $form_args = $r->did_post ? $r->post_args : $r->get_args;
     my $vars      = {};
 
-    $vars->{maxlength_user} = $LJ::USERNAME_MAXLENGTH;
-
     $vars->{formdata} = $form_args;
     $vars->{showtable} =
         ( $form_args->{'user'} || $form_args->{'admin'} || $form_args->{'type'} ) ? 1 : 0;
@@ -166,8 +164,6 @@ sub userlog_controller {
     my $r         = DW::Request->get;
     my $form_args = $r->did_post ? $r->post_args : $r->get_args;
     my $vars      = {};
-
-    $vars->{maxlength_user} = $LJ::USERNAME_MAXLENGTH;
 
     $vars->{user} = LJ::canonical_username( $form_args->{user} );
 

--- a/cgi-bin/DW/Controller/Admin/UserViews.pm
+++ b/cgi-bin/DW/Controller/Admin/UserViews.pm
@@ -114,8 +114,6 @@ sub impersonate_controller {
     $vars->{errors}   = $errors;
     $vars->{formdata} = $form_args;
 
-    $vars->{maxlength_user} = $LJ::USERNAME_MAXLENGTH;
-
     return DW::Template->render_template( 'admin/impersonate.tt', $vars );
 }
 
@@ -128,8 +126,6 @@ sub recent_comments_controller {
     my $r         = DW::Request->get;
     my $form_args = $r->get_args;
     my $vars      = {};
-
-    $vars->{maxlength_user} = $LJ::USERNAME_MAXLENGTH;
 
     if ( my $user = $form_args->{user} ) {
         $vars->{u} = ( $user =~ /^\#(\d+)/ ) ? LJ::load_userid($1) : LJ::load_user($user);
@@ -177,8 +173,6 @@ sub styleinfo_controller {
     my $vars      = {};
 
     $vars->{formdata} = $form_args;
-
-    $vars->{maxlength_user} = $LJ::USERNAME_MAXLENGTH;
 
     return DW::Template->render_template( 'admin/styleinfo.tt', $vars )
         unless $form_args->{user};

--- a/cgi-bin/DW/Controller/ChangeEmail.pm
+++ b/cgi-bin/DW/Controller/ChangeEmail.pm
@@ -37,10 +37,7 @@ sub changeemail_handler {
     my $u      = $rv->{u};
     my $remote = $rv->{remote};
 
-    my $vars;
-    $vars->{password_maxlength} = $LJ::PASSWORD_MAXLENGTH;
-    $vars->{u}                  = $u;
-    $vars->{remote}             = $remote;
+    my $vars = { u => $u, remote => $remote };
 
     return error_ml('/changeemail.tt.error.suspended') if $u->is_suspended;
 

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -275,8 +275,6 @@ sub new_handler {
 
     $vars->{action} = { url => LJ::create_url( undef, keep_args => 1 ), };
 
-    $vars->{password_maxlength} = $LJ::PASSWORD_MAXLENGTH;
-
     $vars->{js_for_rte} = LJ::rte_js_vars();
     $vars->{sitevalues} = to_json( \@sitevalues );
 

--- a/cgi-bin/DW/Controller/MassPrivacy.pm
+++ b/cgi-bin/DW/Controller/MassPrivacy.pm
@@ -191,19 +191,18 @@ sub editprivacy_handler {
     my @days   = map { $_, $_ } ( 1 .. 31 );
     my @months = map { $_, LJ::Lang::month_long_ml($_) } ( 1 .. 12 );
     my $vars   = {
-        mode               => $mode,
-        POST               => $POST,
-        more_public        => $more_public,
-        day_list           => \@days,
-        month_list         => \@months,
-        security_list      => \@security,
-        security           => \%security,
-        errors             => $errors,
-        s_dt               => $s_dt,
-        e_dt               => $e_dt,
-        posts              => $posts,
-        u                  => $u,
-        password_maxlength => $LJ::PASSWORD_MAXLENGTH,
+        mode          => $mode,
+        POST          => $POST,
+        more_public   => $more_public,
+        day_list      => \@days,
+        month_list    => \@months,
+        security_list => \@security,
+        security      => \%security,
+        errors        => $errors,
+        s_dt          => $s_dt,
+        e_dt          => $e_dt,
+        posts         => $posts,
+        u             => $u,
     };
 
     return DW::Template->render_template( 'editprivacy.tt', $vars );

--- a/cgi-bin/DW/Controller/Media.pm
+++ b/cgi-bin/DW/Controller/Media.pm
@@ -88,7 +88,6 @@ sub media_manage_handler {
     $rv->{convert_time}   = \&LJ::mysql_time;
     $rv->{adminmode}      = $adminmode ? 1 : 0;
     $rv->{user}           = $user;
-    $rv->{maxlength_user} = $LJ::USERNAME_MAXLENGTH;
 
     my $media_usage = DW::Media->get_usage_for_user($u);
     my $media_quota = DW::Media->get_quota_for_user($u);

--- a/cgi-bin/DW/Controller/Settings.pm
+++ b/cgi-bin/DW/Controller/Settings.pm
@@ -496,10 +496,7 @@ sub lostinfo_handler {
     my $form_args = $r->post_args;
     my $captcha   = DW::Captcha->new( 'lostinfo', %{$form_args} );
 
-    my $vars = {
-        captcha            => $captcha,
-        username_maxlength => $LJ::USERNAME_MAXLENGTH,
-    };
+    my $vars = { captcha => $captcha };
 
     return DW::Template->render_template( 'settings/lostinfo.tt', $vars )
         unless $r->did_post;

--- a/cgi-bin/DW/Controller/Settings.pm
+++ b/cgi-bin/DW/Controller/Settings.pm
@@ -481,9 +481,6 @@ sub changepassword_handler {
 
         formdata => $post || { user => $remote ? $remote->user : "" },
         errors   => $errors,
-
-        username_maxlength => $LJ::USERNAME_MAXLENGTH,
-        password_maxlength => $LJ::PASSWORD_MAXLENGTH,
     };
     return DW::Template->render_template( 'settings/changepassword.tt', $vars );
 }

--- a/cgi-bin/DW/Template.pm
+++ b/cgi-bin/DW/Template.pm
@@ -56,6 +56,7 @@ my $site_constants = Template::Namespace::Constants->new(
         },
 
         maxlength_user => $LJ::USERNAME_MAXLENGTH,
+        maxlength_pass => $LJ::PASSWORD_MAXLENGTH,
     }
 );
 

--- a/cgi-bin/DW/Template.pm
+++ b/cgi-bin/DW/Template.pm
@@ -29,7 +29,7 @@ DW::Template - Template Toolkit helpers for Apache2.
 
 =head1 SYNOPSIS
 
-=cut 
+=cut
 
 # setting this to false -- have to explicitly specify which plugins we want.
 $Template::Plugins::PLUGIN_BASE = '';
@@ -54,6 +54,8 @@ my $site_constants = Template::Namespace::Constants->new(
             coppa   => $LJ::COPPA_EMAIL,
             privacy => $LJ::PRIVACY_EMAIL,
         },
+
+        maxlength_user => $LJ::USERNAME_MAXLENGTH,
     }
 );
 
@@ -252,7 +254,7 @@ This will be ignored for 'bml' scopes.
 
 =item B< journal > $opts hashref passed into LJ::make_journal and beyond.
 
-=back 
+=back
 
 =back
 

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1507,8 +1507,6 @@ sub talkform {
         create_link          => '',
         subjecticon_ids      => \@subjecticon_ids,
         editors              => $editors,
-        username_maxlength   => $LJ::USERNAME_MAXLENGTH,
-        password_maxlength   => $LJ::PASSWORD_MAXLENGTH,
 
         foundation_beta => !LJ::BetaFeatures->user_in_beta( $remote => "nos2foundation" ),
 

--- a/views/admin/impersonate.tt
+++ b/views/admin/impersonate.tt
@@ -23,11 +23,11 @@
 <form method='POST'>
 [% dw.form_auth %]
 [% form.textbox( label = dw.ml( '.form.username' ), id='impersonate_username',
-                 size = maxlength_user, maxlength = maxlength_user,
+                 size = site.maxlength_user, maxlength = site.maxlength_user,
                  name = 'username' ) %]
 <br />
 [% form.textbox( label = dw.ml( '.form.password' ), id='impersonate_password',
-                 size = maxlength_user, type = 'password', value = '',
+                 size = site.maxlength_user, type = 'password', value = '',
                  name = 'password' ) %]
 <br />
 [% form.textbox( label = dw.ml( '.form.reason' ), id='impersonate_reason',

--- a/views/admin/invites/promo-edit.tt
+++ b/views/admin/invites/promo-edit.tt
@@ -76,7 +76,7 @@
                   name = 'suggest_journal', id = 'suggest_journal',
                   value = suggest_u ? suggest_u.username
                                     : formdata.suggest_journal,
-                  size = 28, maxlength = maxlength_user ) -%]
+                  size = 28, maxlength = site.maxlength_user ) -%]
   </p>
   <p>
 

--- a/views/admin/priv/index.tt
+++ b/views/admin/priv/index.tt
@@ -28,7 +28,7 @@
 <p>
 <form method='get' action='index'>
   [% form.textbox( name = 'user', label = dw.ml( '.label.viewuserprivs' ),
-                   size = maxlength_user, maxlength = maxlength_user ) %]
+                   size = site.maxlength_user, maxlength = site.maxlength_user ) %]
   [% form.submit(  value = dw.ml( '.btn.load' ) ) %]
 </form>
 </p>

--- a/views/admin/priv/viewpriv.tt
+++ b/views/admin/priv/viewpriv.tt
@@ -120,7 +120,7 @@
 
   <p>
         [% form.textbox( label = dw.ml( '.label.grantuser' ), name = 'grantuser',
-                         size = maxlength_user, maxlength = maxlength_user ) %]
+                         size = site.maxlength_user, maxlength = site.maxlength_user ) %]
 
         [% form.textbox( label = dw.ml( '.label.grantarg' ), name = 'arg',
                          size = 20, maxlength = 40, value = arg ) %]

--- a/views/admin/recent_comments.tt
+++ b/views/admin/recent_comments.tt
@@ -29,7 +29,7 @@
 
 <form method='GET'>
 [% form.textbox( label = dw.ml( '.label.form' ), name='user',
-                 size = maxlength_user, maxlength = maxlength_user );
+                 size = site.maxlength_user, maxlength = site.maxlength_user );
 
    form.submit( value = dw.ml( '.btn.load' ) ) %]
 </form>

--- a/views/admin/spamreports/index.tt
+++ b/views/admin/spamreports/index.tt
@@ -37,7 +37,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <li><form method="GET" action="spamreports" class="usersearch">
       [% form.textbox( label = dw.ml( '.reports.user.individual' ),
                        id = "repu", name = "what",
-                       size = maxlength_user, maxlength = maxlength_user ) %]
+                       size = site.maxlength_user, maxlength = site.maxlength_user ) %]
       [% form.hidden( name = "by", value = "poster" ) %]
       [% form.hidden( name = "mode", value = "view" ) %]
       </form>
@@ -47,7 +47,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <li><form method="GET" action="spamreports" class="usersearch">
       [% form.textbox( label = dw.ml( '.reports.journal.individual' ),
                        id = "repj", name = "what",
-                       size = maxlength_user, maxlength = maxlength_user ) %]
+                       size = site.maxlength_user, maxlength = site.maxlength_user ) %]
       [% form.hidden( name = "by", value = "journal" ) %]
       [% form.hidden( name = "mode", value = "view" ) %]
       </form>

--- a/views/admin/statushistory.tt
+++ b/views/admin/statushistory.tt
@@ -40,11 +40,11 @@
   [% form.hidden( name = "flow" ) %]
 
   [% form.textbox( label = dw.ml( '.label.user' ),
-                   maxlength = maxlength_user, size = maxlength_user,
+                   maxlength = site.maxlength_user, size = site.maxlength_user,
                    name = 'user' ) %]
 
   [% form.textbox( label = dw.ml( '.label.admin' ),
-                   maxlength = maxlength_user, size = maxlength_user,
+                   maxlength = site.maxlength_user, size = site.maxlength_user,
                    name = 'admin' ) %]
 
   [% form.textbox( label = dw.ml( '.label.type' ),

--- a/views/admin/styleinfo.tt
+++ b/views/admin/styleinfo.tt
@@ -28,7 +28,7 @@
 
 <form method='POST'>
 [% form.textbox( label = dw.ml( '.label.viewuser' ), name = 'user',
-                 size = maxlength_user, maxlength = maxlength_user );
+                 size = site.maxlength_user, maxlength = site.maxlength_user );
 
    form.submit( value = dw.ml( '.btn.view' ) ) %]
 </form>
@@ -46,7 +46,7 @@
   <ul>
     [%- FOREACH layer IN sort_keys( s2style.layer );
           layerid = s2style.layer.$layer -%]
-    <li>[% layer %]: 
+    <li>[% layer %]:
       [%- IF layerid %]
       <a href='[% dw.create_url( '/customize/advanced/layerbrowse',
                                  args => { id => layerid } ) %]'>

--- a/views/admin/userlog.tt
+++ b/views/admin/userlog.tt
@@ -40,7 +40,7 @@
 <form method='post' action='userlog'>
   [% dw.form_auth %]
   [% form.textbox( label = dw.ml( '.label.username' ),
-                   maxlength = maxlength_user, size = maxlength_user,
+                   maxlength = site.maxlength_user, size = site.maxlength_user,
                    name = 'user', value = user );
      form.submit( value = dw.ml( '.btn.view' ) ) %]
 </form>

--- a/views/changeemail.tt
+++ b/views/changeemail.tt
@@ -36,7 +36,7 @@ the same terms as Perl itself. For a copy of the license, please reference
     [% ELSE %]
         <p>[% '.instructions' | ml( sitename = site.nameshort ) %]</p>
     [% END %]
-    
+
     [%# Warn if logged in and not validated %]
     [% IF notvalidated %]
         <div class="message-box info-box">
@@ -48,10 +48,10 @@ the same terms as Perl itself. For a copy of the license, please reference
     <form method="get">
         [% authas_html %]
     </form>
-    
+
     <form action='[% site.root %]/changeemail[% getextra %]' method='post'>
         [% dw.form_auth() %]
-    
+
         <br/><br/><div>[% '.label.username' | ml %]<br />[% u.ljuser_display %]</div><br/>
         <div>[% '.label.oldemail' | ml %]<br />
             [% IF noemail %]
@@ -68,11 +68,11 @@ the same terms as Perl itself. For a copy of the license, please reference
             </div><br />
             [% UNLESS is_identity %]
                 <div>[% '.label.password2' | ml(remote = remote.ljuser_display) %]<br />
-                <input type='password' name='password' size='50' maxlength='[% password_maxlength %]' tabindex='2' /></div>
+                <input type='password' name='password' size='50' maxlength='[% site.maxlength_pass %]' tabindex='2' /></div>
             [% END %]
         </div>
         <br />
-        
+
         <div class='action-box'><div class='inner'>
         <input type='submit' tabindex='3' value="[% '.btn.change' | ml %]" />
         </div></div><div class='clear-floats'></div>

--- a/views/editprivacy.tt
+++ b/views/editprivacy.tt
@@ -4,90 +4,90 @@
 
 [% IF mode == 'init' %]
     <p> [% dw.ml('.intro2', {"aopts" => "href='$site.root/accountstatus/'"}) %] </p>
-	<p> [% dw.ml('.archive', {"aopts" => "href='$u.journal_base/archive/'"}) %] </p>
+    <p> [% dw.ml('.archive', {"aopts" => "href='$u.journal_base/archive/'"}) %] </p>
     <p> [% dw.ml('xpost.respected', {"aopts" => "href='$site.root/manage/settings/?cat=othersites'"}) %] </p>
 
     <form method='post' action='./editprivacy'>
     <h1> [% dw.ml('.timeframe') %] </h1>
     <div class="row">
-        	<div class="columns">
-		        	[%- form.radio( "name" = "time", "id" = "time_all", "value" = "all", selected = (POST.time == 'time_all'), 'label' = dw.ml('.timeframe.all')) -%]
-		    </div>
-	</div>
-	<div class="row">
-		<div class="columns">
-        	[%- form.radio( "name" = "time", "id" = "time_range", "value" = "range", selected = (POST.time == 'time_range'), 'label'= dw.ml('.timeframe.range')) -%]
-			<div class="row">
-				<div class="columns medium-2">
-		        	<span class="right inline">[% dw.ml('.timeframe.range.start') %]:</span>
-		        </div>
-		        <div class="columns medium-2">
-		        	[%- form.textbox( "name" = 's_year', "value" = POST.s_year || '1999', "maxlength" = 4 ) -%]  
-		        </div>
-		        <div class="columns medium-2">
-			       	[%- form.select( "items"   = month_list
-			                 		"name"    = 's_mon'
-			                 		"selected" = POST.s_mon
-			               )
-			        -%] 
-		        </div>
-		        <div class="columns medium-1 end">
-			        [%- form.select( "items"   = day_list
-			                 		"name"    = 's_day'
-			                 		"selected" = POST.s_day
-			               )
-			        -%]
-		        </div>
-			</div>
+            <div class="columns">
+                    [%- form.radio( "name" = "time", "id" = "time_all", "value" = "all", selected = (POST.time == 'time_all'), 'label' = dw.ml('.timeframe.all')) -%]
+            </div>
+    </div>
+    <div class="row">
+        <div class="columns">
+            [%- form.radio( "name" = "time", "id" = "time_range", "value" = "range", selected = (POST.time == 'time_range'), 'label'= dw.ml('.timeframe.range')) -%]
+            <div class="row">
+                <div class="columns medium-2">
+                    <span class="right inline">[% dw.ml('.timeframe.range.start') %]:</span>
+                </div>
+                <div class="columns medium-2">
+                    [%- form.textbox( "name" = 's_year', "value" = POST.s_year || '1999', "maxlength" = 4 ) -%]
+                </div>
+                <div class="columns medium-2">
+                    [%- form.select( "items"   = month_list
+                                    "name"    = 's_mon'
+                                    "selected" = POST.s_mon
+                           )
+                    -%]
+                </div>
+                <div class="columns medium-1 end">
+                    [%- form.select( "items"   = day_list
+                                    "name"    = 's_day'
+                                    "selected" = POST.s_day
+                           )
+                    -%]
+                </div>
+            </div>
 
-			<div class="row">
-				<div class="columns medium-2">
-		        	<span class="right inline">[% dw.ml('.timeframe.range.end') %]:</span>
-		        </div>
-		        <div class="columns medium-2">
-		        	[%- form.textbox( "name" = 'e_year', "value" = POST.e_year || '', "maxlength" = 4 ) -%]  
-		        </div>
-		        <div class="columns medium-2">
-			       	[%- form.select( "items"   = month_list
-			                 		"name"    = 'e_mon'
-			                 		"selected" = POST.e_mon
-			               )
-			        -%] 
-		        </div>
-		        <div class="columns medium-1 end">
-			        [%- form.select( "items"   = day_list
-			                 		"name"    = 'e_day'
-			                 		"selected" = POST.e_day
-			               )
-			        -%]
-		        </div>
-			</div>
+            <div class="row">
+                <div class="columns medium-2">
+                    <span class="right inline">[% dw.ml('.timeframe.range.end') %]:</span>
+                </div>
+                <div class="columns medium-2">
+                    [%- form.textbox( "name" = 'e_year', "value" = POST.e_year || '', "maxlength" = 4 ) -%]
+                </div>
+                <div class="columns medium-2">
+                    [%- form.select( "items"   = month_list
+                                    "name"    = 'e_mon'
+                                    "selected" = POST.e_mon
+                           )
+                    -%]
+                </div>
+                <div class="columns medium-1 end">
+                    [%- form.select( "items"   = day_list
+                                    "name"    = 'e_day'
+                                    "selected" = POST.e_day
+                           )
+                    -%]
+                </div>
+            </div>
 
-		</div>
-		</div>
+        </div>
+        </div>
         <h1> [% dw.ml('.privacy') %] </h1>
         <div class="row">
-    		<div class="columns large-1">
-    			<span class="inline right"><b>From:</b></span>
-    		</div>
-    		<div class="columns large-3">
-		        [%- form.select( "items"   = security_list
-		                         "name"    = 's_security'
-		                         "selected" = POST.s_security
-		                       )
-		        -%]
-	        </div>
-   			<div class="columns large-1">
-     			<span class="inline right"><b>To:</b></span>
-	         </div>
-	         <div class="columns large-3 end">
-		         [%- form.select( "items"   = security_list
-		                         "name"    = 'e_security'
-		                         "selected" = POST.e_security
-		                       )
-		        -%]
-	        </div>
-		</div>
+            <div class="columns large-1">
+                <span class="inline right"><b>From:</b></span>
+            </div>
+            <div class="columns large-3">
+                [%- form.select( "items"   = security_list
+                                 "name"    = 's_security'
+                                 "selected" = POST.s_security
+                               )
+                -%]
+            </div>
+            <div class="columns large-1">
+                <span class="inline right"><b>To:</b></span>
+             </div>
+             <div class="columns large-3 end">
+                 [%- form.select( "items"   = security_list
+                                 "name"    = 'e_security'
+                                 "selected" = POST.e_security
+                               )
+                -%]
+            </div>
+        </div>
 
 
         [% dw.form_auth() %]
@@ -95,26 +95,26 @@
         <p>[% form.submit(value = dw.ml('.button.update')) %]</p>
         </form>
 
-	[% ELSIF mode == 'change' %]
+    [% ELSIF mode == 'change' %]
 
         <p>Change [% security.${POST.s_security}.1 %] posts to [% security.${POST.e_security}.1 -%]
         [%- ", between $s_dt.ymd and $e_dt.ymd" IF POST.time == 'range' %]
-		</p>
+        </p>
         <p>[% dw.ml('.matching', {'posts' => posts}) %]</p>
 
         [% IF posts %]
             <h2>[% dw.ml('.rusure') %]</h2>
-        	<form method='post' action='./editprivacy'>
+            <form method='post' action='./editprivacy'>
             [% dw.form_auth() %]
             [% form.hidden( name = 'mode', value = 'amsure') %]
             [% form.hidden( name = 's_unixtime', value = s_dt.epoch) %]
             [% form.hidden( name = 'e_unixtime', value = e_dt.epoch) %]
             [% form.hidden( name = 's_security', value = POST.s_security) %]
             [% form.hidden( name = 'e_security', value = POST.e_security) %]
-			[% form.hidden( name = 'time', value = POST.time) %]
+            [% form.hidden( name = 'time', value = POST.time) %]
             [% IF more_public %]
             <div class="row">
-            	<div class="columns medium-6 end">
+                <div class="columns medium-6 end">
                 [% form.password(name='password', size='20', maxlength=site.maxlength_pass, label="Password Required") %]
                 </div>
                 </div>
@@ -124,5 +124,5 @@
         [% END %]
 
 [% ELSIF mode == 'amsure' || mode == 'secured' %]
-	<p>[% dw.ml('.notified') %]</p>
+    <p>[% dw.ml('.notified') %]</p>
 [% END %]

--- a/views/editprivacy.tt
+++ b/views/editprivacy.tt
@@ -115,7 +115,7 @@
             [% IF more_public %]
             <div class="row">
             	<div class="columns medium-6 end">
-                [% form.password(name='password', size='20', maxlength=password_maxlength, label="Password Required") %]
+                [% form.password(name='password', size='20', maxlength=site.maxlength_pass, label="Password Required") %]
                 </div>
                 </div>
             [% END %]

--- a/views/entry/login.tt
+++ b/views/entry/login.tt
@@ -32,7 +32,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         type = "password"
         name = "password"
         size = "20"
-        maxlength = password_maxlength
+        maxlength = site.maxlength_pass
         "aria-required" = "true"
     ) -%]
     <input class="button expand" type="submit" name="login" value="[% '.onetime.button.post' | ml %]" aria-describedby="one-time" />

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -276,7 +276,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
           id = 'username'
           label = dw.ml('Username')
           size = 13
-          maxlength = username_maxlength
+          maxlength = site.maxlength_user
           value = comment.user
           style = "background: url('${site.imgroot}/silk/identity/user.png') no-repeat; background-color: #fff; background-position: 0px 50%; padding-left: 18px; color: #00C; font-weight: bold;"
         ) -%]
@@ -287,7 +287,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
           name = 'password'
           id= 'password'
           label = dw.ml('Password')
-          maxlength = password_maxlength
+          maxlength = site.maxlength_pass
           value = comment.password
           size = 18
         ) -%]
@@ -743,7 +743,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
               id = 'username'
               label = dw.ml('Username')
               size = 13
-              maxlength = username_maxlength
+              maxlength = site.maxlength_user
               value = comment.user
               style = "background: url('${site.imgroot}/silk/identity/user.png') no-repeat; background-color: #fff; background-position: 0px 1px; padding-left: 18px; color: #00C; font-weight: bold;"
             ) -%]
@@ -754,7 +754,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
               name = 'password'
               id= 'password'
               label = dw.ml('Password')
-              maxlength = password_maxlength
+              maxlength = site.maxlength_pass
               value = comment.password
               size = 18
             ) -%]

--- a/views/media/index.tt
+++ b/views/media/index.tt
@@ -47,7 +47,7 @@ window.onload = function() {
 
 [%- IF adminmode %]
 <form method='GET'><p>
-  [% form.textbox( maxlength = maxlength_user, size = maxlength_user,
+  [% form.textbox( maxlength = site.maxlength_user, size = site.maxlength_user,
                    label = dw.ml( '.user' ), name = 'user', value = user );
      form.submit( value = dw.ml( '.user.submit' ) ) %]
 </p></form>

--- a/views/settings/changepassword.tt
+++ b/views/settings/changepassword.tt
@@ -35,14 +35,14 @@ the same terms as Perl itself.  For a copy of the license, please reference
             [%- form.textbox(
                     label = dw.ml( '.header.username' )
                     name = 'user'
-                    maxlength = username_maxlength
+                    maxlength = site.maxlength_user
             ) -%]
         </div></div>
         <div class="row"><div class="columns">
             [%- form.password(
                 label = dw.ml( ".currentpassword" )
                 name = "password"
-                maxlength = password_maxlength
+                maxlength = site.maxlength_pass
             ) -%]
         </div></div>
     [%- END -%]
@@ -51,7 +51,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.password(
             label = dw.ml( ".newpassword" )
             name = "newpass1"
-            maxlength = password_maxlength + 1
+            maxlength = site.maxlength_pass + 1
         ) -%]
     </div></div>
 
@@ -59,7 +59,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.password(
             label = dw.ml( ".newpasswordagain" )
             name = "newpass2"
-            maxlength = password_maxlength + 1
+            maxlength = site.maxlength_pass + 1
         ) -%]
     </div></div>
 

--- a/views/settings/lostinfo.tt
+++ b/views/settings/lostinfo.tt
@@ -32,7 +32,7 @@
   <p>[% '.lostpassword.text' | ml( sitename = site.nameshort ) %]</p>
 
   [% form.textbox( label = dw.ml( '.enter_username' ), id = 'userlost',
-                   name = 'user', size = 30, maxlength = username_maxlength,
+                   name = 'user', size = 30, maxlength = site.maxlength_user,
                    onkeyup = 'enable_pass();', onchange = 'enable_pass();' ) %]
 
   <br />


### PR DESCRIPTION
CODE TOUR: no visible impact, unless I messed something up.

Whenever I edited a template that contained a form for a username, it irked me that I had to explicitly pass through the site constant for maximum username length, so I added it to the dictionary of template constants. Then I did the same thing for password length.

These are accessed as `site.maxlength_user` and `site.maxlength_pass`.