### PR TITLE
optionally include expired sysbans in query results

### DIFF
--- a/cgi-bin/DW/Controller/Admin/Sysban.pm
+++ b/cgi-bin/DW/Controller/Admin/Sysban.pm
@@ -153,8 +153,12 @@ sub sysban_controller {
 
         # these results are displayed within the index form
 
-        $vars->{sysbans} = LJ::Sysban::populate_full_by_value( $form_args->{queryvalue},
-            @{ $vars->{sysban_privs} } );
+        my $lookup =
+            $form_args->{expiredcheck}
+            ? sub { LJ::Sysban::populate_full_by_value_with_expired(@_) }
+            : sub { LJ::Sysban::populate_full_by_value(@_) };
+
+        $vars->{sysbans} = $lookup->( $form_args->{queryvalue}, @{ $vars->{sysban_privs} } );
     }
 
     return DW::Template->render_template( 'admin/sysban/index.tt', $vars );

--- a/cgi-bin/LJ/Sysban.pm
+++ b/cgi-bin/LJ/Sysban.pm
@@ -468,9 +468,13 @@ sub _db_sysban_populate_full_by_value {
 
     my $where;
     while ( my ( $banid, $what, $exp, $note ) = $sth->fetchrow_array ) {
-        $where->{$what}->{banid}  = $banid || 0;
-        $where->{$what}->{expire} = $exp   || 0;
-        $where->{$what}->{note}   = $note  || 0;
+        my $data = {
+            banid  => $banid || 0,
+            expire => $exp   || 0,
+            note   => $note  || 0,
+        };
+        $where->{$what} //= [];
+        push @{ $where->{$what} }, $data;
     }
 
     return $where;

--- a/views/admin/spamreports/view.tt
+++ b/views/admin/spamreports/view.tt
@@ -121,7 +121,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
                 <strong>[% '.report.individual.sysban.done' | ml %]</strong>
                 [%- IF remote.has_priv( 'sysban' ) -%]
                     <br/><textarea name='sysban_note' rows='3' cols='60' readonly='1'>
-                    [%- note = reason.talk_ip_test.note;
+                    [%- note = reason.talk_ip_test.last.note;
                         IF note; note | html; ELSE;
                         ".report.individual.syban.nonote" | ml;
                         END -%]

--- a/views/admin/sysban/index.tt
+++ b/views/admin/sysban/index.tt
@@ -47,15 +47,20 @@
 </form>
 </p>
 
-<p>
 <form method='post' action='sysban'>
 [% dw.form_auth %]
+<p>
 [% form.textbox( label = dw.ml( '.label.queryone' ), value = '',
                  name = 'queryvalue', id = 'queryvalue' );
 
    form.submit( name = 'queryone',  value = dw.ml( '.btn.queryone'  ) ) %]
-</form>
 </p>
+<p>
+[% form.checkbox( label = dw.ml( '.label.expiredcheck' ), value = '1',
+                  name = 'expiredcheck', id = 'expiredcheck',
+                  selected = formdata.expiredcheck ) %]
+</p>
+</form>
 
 [%- IF action == 'queryone';
     banquery = formdata.queryvalue | html;
@@ -79,7 +84,7 @@
       [%- END -%]
 </table>
 
-  [%- ELSE -%]
+  [%- ELSIF banquery -%]
 <p>[% '.txt.nomatch' | ml( banquery = banquery ) %]</p>
   [%- END -%]
 

--- a/views/admin/sysban/index.tt
+++ b/views/admin/sysban/index.tt
@@ -75,12 +75,14 @@
     <th>[% '.col.note' | ml %]</th>
   </tr></thead>
 
-      [%- FOREACH ban IN sysbans.pairs -%]
+      [%- FOREACH bantype IN sysbans.keys.sort -%]
+      [%- FOREACH banrow IN sysbans.$bantype -%]
   <tr>
-    <td>[% ban.key %]</td>
-    <td>[% localtime( ban.value.expire ) %]</td>
-    <td>[% ban.value.note | html %]</td>
+    <td>[% bantype %]</td>
+    <td>[% localtime( banrow.expire ) %]</td>
+    <td>[% banrow.note | html %]</td>
   </tr>
+      [%- END -%]
       [%- END -%]
 </table>
 

--- a/views/admin/sysban/index.tt.text
+++ b/views/admin/sysban/index.tt.text
@@ -29,6 +29,8 @@
 
 .header.queryone=Sysbans for [[banquery]]
 
+.label.expiredcheck=Include info for bans that have expired
+
 .label.queryone=Query all sysbans for this value:
 
 .label.type=Act on sysbans of the following type:


### PR DESCRIPTION
CODE TOUR: New admin interface for viewing sysban history.

This does the bare minimum to provide what was requested in #3083 by adding an "Include info for bans that have expired" checkbox in the "Query this value" form on /admin/sysban. There is room for improvement, but this will do for starters.

Fixes #3083.