### PR TITLE
use 'draft-autosave' instead of 'draft' as field keyword

### DIFF
--- a/htdocs/js/pages/entry/drafts.js
+++ b/htdocs/js/pages/entry/drafts.js
@@ -128,7 +128,7 @@ function initDraft(askToRestore) {
    }
 
     // set up event handlers
-    $("#content").on('change', 'input.draft, textarea.draft', null, LJDraft.handleChange);
+    $("#content").on('change', 'input.draft-autosave, textarea.draft-autosave', null, LJDraft.handleChange);
     $("#content").on('input', '#entry-body', null, LJDraft.handleInput);
 
     // Try to save draft when page is closed/hidden

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -197,7 +197,7 @@ postFormInitData.strings = {
                   id = 'editor'
                   select = editors.selected
                   items = editors.items
-                  class = "draft"
+                  class = "draft-autosave"
                 ) -%]
 
                 <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1" target="_blank">[%-
@@ -223,7 +223,7 @@ postFormInitData.strings = {
                     wrap = "soft"
 
                     labelclass = "hidden"
-                    class = "draft"
+                    class = "draft-autosave"
 
                     placeholder = dw.ml(".event.placeholder")
                 ) -%]

--- a/views/entry/module-age_restriction.tt
+++ b/views/entry/module-age_restriction.tt
@@ -33,7 +33,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.select( label = dw.ml( ".label.age_restriction" )
             name = "age_restriction"
             id = "age_restriction"
-            class = "draft"
+            class = "draft-autosave"
 
             items = levelselect
         ) -%]
@@ -43,7 +43,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.textbox( label = dw.ml( ".label.age_restriction_reason" )
             name = "age_restriction_reason"
             id = "age_restriction_reason"
-            class = "draft"
+            class = "draft-autosave"
 
             size = "20"
             maxlength = "255"

--- a/views/entry/module-comments.tt
+++ b/views/entry/module-comments.tt
@@ -21,7 +21,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.select( label = "Comments:"
             name = "comment_settings"
             id = "comment_settings"
-            class = "draft"
+            class = "draft-autosave"
 
             items = [
                 ""              "Journal Default"
@@ -35,7 +35,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.select( label = "Screening:"
             name = "opt_screening"
             id = "opt_screening"
-            class = "draft"
+            class = "draft-autosave"
 
             items = [
                 ""      "Journal Default"

--- a/views/entry/module-currents.tt
+++ b/views/entry/module-currents.tt
@@ -24,7 +24,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.select( label = dw.ml( ".label.current_mood" )
             name = "current_mood"
             id = "js-current-mood"
-            class = "draft"
+            class = "draft-autosave"
 
             items = moodselect
         ) -%]
@@ -34,7 +34,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.textbox( label = dw.ml( ".label.current_mood_other" )
           name = "current_mood_other"
           id = "js-current-mood-other"
-          class = "draft"
+          class = "draft-autosave"
 
           size = "20"
           maxlength = "30"
@@ -45,7 +45,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.textbox( label = dw.ml( ".label.current_music" )
             name = "current_music"
             id = "current-music"
-            class = "draft"
+            class = "draft-autosave"
 
             size="20"
             maxlength="80"
@@ -56,7 +56,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.textbox( label = dw.ml( ".label.current_location" )
             name = "current_location"
             id = "current-location"
-            class = "draft"
+            class = "draft-autosave"
 
             size = "20"
             maxlength = "80"

--- a/views/entry/module-icons.tt
+++ b/views/entry/module-icons.tt
@@ -24,7 +24,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     </div>
     <div class="row">
         <div class="columns">
-            [% INCLUDE "components/icon-select-dropdown.tt" omit_random_button = 1 class = "draft" %]
+            [% INCLUDE "components/icon-select-dropdown.tt" omit_random_button = 1 class = "draft-autosave" %]
         </div>
     </div>
 

--- a/views/entry/module-tags.tt
+++ b/views/entry/module-tags.tt
@@ -20,7 +20,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.textarea( label = dw.ml(".label.tags")
             name = "taglist"
             id = "js-taglist"
-            class = "draft"
+            class = "draft-autosave"
 
             cols = "20"
             rows = "1"


### PR DESCRIPTION
CODE TOUR: Nick pointed out that `draft-autosave` was probably a clearer keyword than just `draft` for marking fields we autosave in drafts. Me in six months will be happy for this.