### PR TITLE
Create styling for dead services that indicate that they're no longer available

### DIFF
--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -221,7 +221,7 @@ sub get_site {
     return $mapped || undef;
 }
 
-sub get_deadsites { return \@deadsites; }
+sub get_deadsites { return @deadsites; }
 
 # returns a list of all supported sites for linking
 sub get_sites { return @all_sites_without_alias; }

--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -160,6 +160,8 @@ $domaintosite{"artstation"}      = $domaintosite{"artstation.com"};
 $domaintosite{"substack"}        = $domaintosite{"substack.com"};
 $domaintosite{"itch"}            = $domaintosite{"itch.io"};
 
+@my deadsites = qw(delicious delicious.com diigo imzy inksome journalfen);
+
 foreach my $value (@all_sites_without_alias) {
     $idtosite{ $value->{siteid} } = $value;
 }

--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -111,7 +111,7 @@ $domaintosite{"furaffinity.com"} =
 $domaintosite{"artstation.com"} =
     DW::External::Site->new( "33", "www.artstation.com", "artstation.com", "ArtStation", "artstation" );
 
-@deadsites =  qw(delicious delicious.com diigo imzy inksome journalfen);
+@deadsites = ("del.icio.us", "diigo.com", "imzy.com", "inksome.com", "journalfen.net");
 
 @all_sites_without_alias = values %domaintosite;
 

--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -221,7 +221,7 @@ sub get_site {
     return $mapped || undef;
 }
 
-sub get_deadsites { return @deadsites; }
+sub get_deadsites { return \@deadsites; }
 
 # returns a list of all supported sites for linking
 sub get_sites { return @all_sites_without_alias; }

--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -160,7 +160,7 @@ $domaintosite{"artstation"}      = $domaintosite{"artstation.com"};
 $domaintosite{"substack"}        = $domaintosite{"substack.com"};
 $domaintosite{"itch"}            = $domaintosite{"itch.io"};
 
-@my deadsites = qw(delicious delicious.com diigo imzy inksome journalfen);
+my @deadsites = qw(delicious delicious.com diigo imzy inksome journalfen);
 
 foreach my $value (@all_sites_without_alias) {
     $idtosite{ $value->{siteid} } = $value;

--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -31,6 +31,7 @@ LJ::ModuleLoader->require_subclasses("DW::External::Site");
 my %domaintosite;
 my %idtosite;
 my @all_sites_without_alias;
+my @deadsites;
 
 ### static initializers
 # with tld
@@ -110,6 +111,8 @@ $domaintosite{"furaffinity.com"} =
 $domaintosite{"artstation.com"} =
     DW::External::Site->new( "33", "www.artstation.com", "artstation.com", "ArtStation", "artstation" );
 
+@deadsites =  qw(delicious delicious.com diigo imzy inksome journalfen);
+
 @all_sites_without_alias = values %domaintosite;
 
 # without tld
@@ -159,8 +162,6 @@ $domaintosite{"fa"}              = $domaintosite{"furaffinity.com"};
 $domaintosite{"artstation"}      = $domaintosite{"artstation.com"};
 $domaintosite{"substack"}        = $domaintosite{"substack.com"};
 $domaintosite{"itch"}            = $domaintosite{"itch.io"};
-
-my @deadsites = qw(delicious delicious.com diigo imzy inksome journalfen);
 
 foreach my $value (@all_sites_without_alias) {
     $idtosite{ $value->{siteid} } = $value;
@@ -219,6 +220,8 @@ sub get_site {
 
     return $mapped || undef;
 }
+
+sub get_deadsites { return @deadsites; }
 
 # returns a list of all supported sites for linking
 sub get_sites { return @all_sites_without_alias; }

--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -31,7 +31,7 @@ LJ::ModuleLoader->require_subclasses("DW::External::Site");
 my %domaintosite;
 my %idtosite;
 my @all_sites_without_alias;
-my @deadsites;
+our @deadsites;
 
 ### static initializers
 # with tld

--- a/cgi-bin/DW/External/Site/Delicious.pm
+++ b/cgi-bin/DW/External/Site/Delicious.pm
@@ -57,19 +57,4 @@ sub profile_url {
     return 'http://' . $self->{hostname} . '/stacks/' . $u->user;
 }
 
-# argument: DW::External::User
-# returns info for the badge image (userhead icon) for this user
-sub badge_image {
-    my ( $self, $u ) = @_;
-    croak 'need a DW::External::User'
-        unless $u && ref $u eq 'DW::External::User';
-
-    # for lack of anything better, let's use the favicon
-    return {
-        url    => "https://del.icio.us/favicon.ico",
-        width  => 16,
-        height => 16,
-    };
-}
-
 1;

--- a/cgi-bin/DW/External/Site/Delicious.pm
+++ b/cgi-bin/DW/External/Site/Delicious.pm
@@ -63,7 +63,7 @@ sub badge_image {
         unless $u && ref $u eq 'DW::External::User';
 
     return {
-        url    => "/silk/identity/user.png",
+        url    => "/silk/identity/user_other.png",
         width  => 16,
         height => 16,
     };

--- a/cgi-bin/DW/External/Site/Delicious.pm
+++ b/cgi-bin/DW/External/Site/Delicious.pm
@@ -57,4 +57,16 @@ sub profile_url {
     return 'http://' . $self->{hostname} . '/stacks/' . $u->user;
 }
 
+sub badge_image {
+    my ( $self, $u ) = @_;
+    croak 'need a DW::External::User'
+        unless $u && ref $u eq 'DW::External::User';
+
+    return {
+        url    => "/silk/identity/user.png",
+        width  => 16,
+        height => 16,
+    };
+}
+
 1;

--- a/cgi-bin/DW/External/Site/Delicious.pm
+++ b/cgi-bin/DW/External/Site/Delicious.pm
@@ -63,7 +63,7 @@ sub badge_image {
         unless $u && ref $u eq 'DW::External::User';
 
     return {
-        url    => "/silk/identity/user_other.png",
+        url    => "/img/silk/identity/user_other.png",
         width  => 16,
         height => 16,
     };

--- a/cgi-bin/DW/External/Site/Diigo.pm
+++ b/cgi-bin/DW/External/Site/Diigo.pm
@@ -54,4 +54,16 @@ sub profile_url {
     return 'http://' . $self->{hostname} . '/profile/' . $u->user;
 }
 
+sub badge_image {
+    my ( $self, $u ) = @_;
+    croak 'need a DW::External::User'
+        unless $u && ref $u eq 'DW::External::User';
+
+    return {
+        url    => "/silk/identity/user.png",
+        width  => 16,
+        height => 16,
+    };
+}
+
 1;

--- a/cgi-bin/DW/External/Site/Diigo.pm
+++ b/cgi-bin/DW/External/Site/Diigo.pm
@@ -54,19 +54,4 @@ sub profile_url {
     return 'http://' . $self->{hostname} . '/profile/' . $u->user;
 }
 
-# argument: DW::External::User
-# returns info for the badge image (userhead icon) for this user
-sub badge_image {
-    my ( $self, $u ) = @_;
-    croak 'need a DW::External::User'
-        unless $u && ref $u eq 'DW::External::User';
-
-    # for lack of anything better, let's use the favicon
-    return {
-        url    => "http://www.diigo.com/favicon.ico",
-        width  => 16,
-        height => 16,
-    };
-}
-
 1;

--- a/cgi-bin/DW/External/Site/Diigo.pm
+++ b/cgi-bin/DW/External/Site/Diigo.pm
@@ -60,7 +60,7 @@ sub badge_image {
         unless $u && ref $u eq 'DW::External::User';
 
     return {
-        url    => "/silk/identity/user_other.png",
+        url    => "/img/silk/identity/user_other.png",
         width  => 16,
         height => 16,
     };

--- a/cgi-bin/DW/External/Site/Diigo.pm
+++ b/cgi-bin/DW/External/Site/Diigo.pm
@@ -60,7 +60,7 @@ sub badge_image {
         unless $u && ref $u eq 'DW::External::User';
 
     return {
-        url    => "/silk/identity/user.png",
+        url    => "/silk/identity/user_other.png",
         width  => 16,
         height => 16,
     };

--- a/cgi-bin/DW/External/Site/Imzy.pm
+++ b/cgi-bin/DW/External/Site/Imzy.pm
@@ -53,19 +53,4 @@ sub profile_url {
     return 'https://' . $self->{hostname} . "/@" . $u->user;
 }
 
-# argument: DW::External::User
-# returns info for the badge image (userhead icon) for this user
-sub badge_image {
-    my ( $self, $u ) = @_;
-    croak 'need a DW::External::User'
-        unless $u && ref $u eq 'DW::External::User';
-
-    # for lack of anything better, let's use the favicon
-    return {
-        url    => $LJ::IMGPREFIX . '/external/imzy.png',
-        width  => 16,
-        height => 16,
-    };
-}
-
 1;

--- a/cgi-bin/DW/External/Site/Imzy.pm
+++ b/cgi-bin/DW/External/Site/Imzy.pm
@@ -53,4 +53,16 @@ sub profile_url {
     return 'https://' . $self->{hostname} . "/@" . $u->user;
 }
 
+sub badge_image {
+    my ( $self, $u ) = @_;
+    croak 'need a DW::External::User'
+        unless $u && ref $u eq 'DW::External::User';
+
+    return {
+        url    => "/silk/identity/user.png",
+        width  => 16,
+        height => 16,
+    };
+}
+
 1;

--- a/cgi-bin/DW/External/Site/Imzy.pm
+++ b/cgi-bin/DW/External/Site/Imzy.pm
@@ -59,7 +59,7 @@ sub badge_image {
         unless $u && ref $u eq 'DW::External::User';
 
     return {
-        url    => "/silk/identity/user.png",
+        url    => "/silk/identity/user_other.png",
         width  => 16,
         height => 16,
     };

--- a/cgi-bin/DW/External/Site/Imzy.pm
+++ b/cgi-bin/DW/External/Site/Imzy.pm
@@ -59,7 +59,7 @@ sub badge_image {
         unless $u && ref $u eq 'DW::External::User';
 
     return {
-        url    => "/silk/identity/user_other.png",
+        url    => "/img/silk/identity/user_other.png",
         width  => 16,
         height => 16,
     };

--- a/cgi-bin/DW/External/Site/Inksome.pm
+++ b/cgi-bin/DW/External/Site/Inksome.pm
@@ -48,19 +48,4 @@ sub journal_url {
     return "http://$user.$self->{domain}/";
 }
 
-# argument: DW::External::User
-# returns info for the badge image (head icon) for this user
-sub badge_image {
-    my ( $self, $u ) = @_;
-    croak 'need a DW::External::User'
-        unless $u && ref $u eq 'DW::External::User';
-
-    # Inksome went away, so just assume every account is personal
-    return {
-        url    => "$LJ::IMGPREFIX/external/ink-userinfo.gif",
-        width  => 17,
-        height => 17,
-    };
-}
-
 1;

--- a/cgi-bin/DW/External/Site/Inksome.pm
+++ b/cgi-bin/DW/External/Site/Inksome.pm
@@ -54,7 +54,7 @@ sub badge_image {
         unless $u && ref $u eq 'DW::External::User';
 
     return {
-        url    => "/silk/identity/user.png",
+        url    => "/silk/identity/user_other.png",
         width  => 16,
         height => 16,
     };

--- a/cgi-bin/DW/External/Site/Inksome.pm
+++ b/cgi-bin/DW/External/Site/Inksome.pm
@@ -48,4 +48,16 @@ sub journal_url {
     return "http://$user.$self->{domain}/";
 }
 
+sub badge_image {
+    my ( $self, $u ) = @_;
+    croak 'need a DW::External::User'
+        unless $u && ref $u eq 'DW::External::User';
+
+    return {
+        url    => "/silk/identity/user.png",
+        width  => 16,
+        height => 16,
+    };
+}
+
 1;

--- a/cgi-bin/DW/External/Site/Inksome.pm
+++ b/cgi-bin/DW/External/Site/Inksome.pm
@@ -54,7 +54,7 @@ sub badge_image {
         unless $u && ref $u eq 'DW::External::User';
 
     return {
-        url    => "/silk/identity/user_other.png",
+        url    => "/img/silk/identity/user_other.png",
         width  => 16,
         height => 16,
     };

--- a/cgi-bin/DW/External/Site/JournalFen.pm
+++ b/cgi-bin/DW/External/Site/JournalFen.pm
@@ -41,7 +41,7 @@ sub badge_image {
         unless $u && ref $u eq 'DW::External::User';
 
     return {
-        url    => "/silk/identity/user_other.png",
+        url    => "/img/silk/identity/user_other.png",
         width  => 16,
         height => 16,
     };

--- a/cgi-bin/DW/External/Site/JournalFen.pm
+++ b/cgi-bin/DW/External/Site/JournalFen.pm
@@ -41,7 +41,7 @@ sub badge_image {
         unless $u && ref $u eq 'DW::External::User';
 
     return {
-        url    => "/silk/identity/user.png",
+        url    => "/silk/identity/user_other.png",
         width  => 16,
         height => 16,
     };

--- a/cgi-bin/DW/External/Site/JournalFen.pm
+++ b/cgi-bin/DW/External/Site/JournalFen.pm
@@ -35,6 +35,18 @@ sub accepts {
     return bless { hostname => 'journalfen.net' }, $class;
 }
 
+sub badge_image {
+    my ( $self, $u ) = @_;
+    croak 'need a DW::External::User'
+        unless $u && ref $u eq 'DW::External::User';
+
+    return {
+        url    => "/silk/identity/user.png",
+        width  => 16,
+        height => 16,
+    };
+}
+
 sub canonical_username {
     return LJ::canonical_username( $_[1] );
 }

--- a/cgi-bin/DW/External/Site/JournalFen.pm
+++ b/cgi-bin/DW/External/Site/JournalFen.pm
@@ -35,28 +35,6 @@ sub accepts {
     return bless { hostname => 'journalfen.net' }, $class;
 }
 
-# argument: DW::External::User
-# returns info for the badge image (head icon) for this user
-sub badge_image {
-    my ( $self, $u ) = @_;
-    croak 'need a DW::External::User'
-        unless $u && ref $u eq 'DW::External::User';
-
-    my $type = $self->journaltype($u) || 'P';
-    my $gif  = {
-        P => [ '/external/lj-userinfo.gif',   17, 17 ],
-        C => [ '/external/lj-community.gif',  16, 16 ],
-        Y => [ '/external/lj-syndicated.gif', 16, 16 ],
-    };
-
-    my $img = $gif->{$type};
-    return {
-        url    => $LJ::IMGPREFIX . $img->[0],
-        width  => $img->[1],
-        height => $img->[2],
-    };
-}
-
 sub canonical_username {
     return LJ::canonical_username( $_[1] );
 }

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -69,7 +69,7 @@ sub ljuser_display {
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
 
-    if (grep( /^$domain$/, DW::External::Site::@deadsites)) {
+    if (grep( /^$domain$/, DW::External::Site::get_deadsites)) {
         $opts{no_link} = 1;
     }
 

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -69,7 +69,7 @@ sub ljuser_display {
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
 
-    if (grep( /^$domain$/, DW::External::Site::deadsites)) {
+    if (grep( /^$domain$/, DW::External::Site::@deadsites)) {
         $opts{no_link} = 1;
     }
 

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -61,7 +61,7 @@ sub site {
 sub ljuser_display {
     my ( $self, %opts ) = @_;
     my @deadsites;
-    my $nolink;
+    my $nolink = 0;
     my $user        = $self->user;
     my $profile_url = $self->site->profile_url($self);
     my $journal_url = $self->site->journal_url($self);
@@ -71,7 +71,7 @@ sub ljuser_display {
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
     @deadsites =  qw(delicious delicious.com diigo imzy inksome journalfen);
 
-    if (grep( /^$domain$/, @deadsites )) {
+    if ($domain ~~ @deadsites) {
         $nolink = 1;
     }
 

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -70,7 +70,7 @@ sub ljuser_display {
     $badge_image->{url} = LJ::CleanHTML::https_url( $badge_image->{url} );
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
-    @deadsites =  qw(delicious delicious.com diigo imzy inksome journalfen);
+    @deadsites =  qw(del.icio.us diigo.com imzy.com inksome.com journalfen.net);
 
     $nolink = 1 if (first {$domain eq $_} @deadsites);
 

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -77,7 +77,7 @@ sub ljuser_display {
     $nolink = $nolink || $opts{no_link};
 
     return
-          (first {$domain eq $_} @DW::External::Site::deadsites)."<span style='white-space: nowrap;'$display_class>"
+          (@DW::External::Site::deadsites)."<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -69,9 +69,9 @@ sub ljuser_display {
     $badge_image->{url} = LJ::CleanHTML::https_url( $badge_image->{url} );
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
-    @deadsites = DW::External::Site::get_deadsites()
+    @deadsites = DW::External::Site::get_deadsites();
 
-    if (grep( /^$domain$/, @deadsites)) {
+    if (grep( /^$domain$/, @deadsites )) {
         $nolink = 1;
     }
 

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -70,14 +70,14 @@ sub ljuser_display {
     $badge_image->{url} = LJ::CleanHTML::https_url( $badge_image->{url} );
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
-    @deadsites =  qw(del.icio.us diigo.com imzy.com inksome.com journalfen.net);
+    @deadsites = ("del.icio.us", "diigo.com", "imzy.com", "inksome.com", "journalfen.net");
 
     $nolink = 1 if (first {$domain eq $_} @DW::External::Site::deadsites);
 
     $nolink = $nolink || $opts{no_link};
 
     return
-          @DW::External::Site::deadsites."<span style='white-space: nowrap;'$display_class>"
+          $domain."<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -20,6 +20,7 @@ package DW::External::User;
 use strict;
 use Carp qw/ croak /;
 use DW::External::Site;
+use List::Util qw(first); 
 use LJ::CleanHTML;
 
 # given a site (url) and a user (string), construct an external
@@ -71,9 +72,7 @@ sub ljuser_display {
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
     @deadsites =  qw(delicious delicious.com diigo imzy inksome journalfen);
 
-    if ($domain ~~ @deadsites) {
-        $nolink = 1;
-    }
+    $nolink = 1 if (first {$domain eq $_} @deadsites);
 
     $nolink = $nolink || $opts{no_link};
 

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -76,7 +76,7 @@ sub ljuser_display {
     $nolink = $nolink || $opts{no_link};
 
     return
-          grep( /^$domain$/, DW::External::Site::get_deadsites)."<span style='white-space: nowrap;'$display_class>"
+          DW::External::Site::get_deadsites."<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -77,7 +77,7 @@ sub ljuser_display {
     $nolink = $nolink || $opts{no_link};
 
     return
-          $domain."<span style='white-space: nowrap;'$display_class>"
+          @DW::External::Site::deadsites."<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -72,7 +72,7 @@ sub ljuser_display {
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
     @deadsites =  qw(del.icio.us diigo.com imzy.com inksome.com journalfen.net);
 
-    $nolink = 1 if (first {$domain eq $_} @deadsites);
+    $nolink = 1 if (first {$domain eq $_} DW::External::Site->get_deadsites);
 
     $nolink = $nolink || $opts{no_link};
 

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -77,7 +77,7 @@ sub ljuser_display {
     $nolink = $nolink || $opts{no_link};
 
     return
-          (first {$domain eq $_} @deadsites)."<span style='white-space: nowrap;'$display_class>"
+          $domain."<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -69,14 +69,14 @@ sub ljuser_display {
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
 
-    if (grep( /^$domain$/, DW::External::Site::get_deadsites)) {
+    if (grep( /^$domain$/, DW::External::Site::get_deadsites())) {
         $nolink = 1;
     }
 
     $nolink = $nolink || $opts{no_link};
 
     return
-          DW::External::Site::get_deadsites."<span style='white-space: nowrap;'$display_class>"
+          DW::External::Site::get_deadsites()."<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -70,14 +70,13 @@ sub ljuser_display {
     $badge_image->{url} = LJ::CleanHTML::https_url( $badge_image->{url} );
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
-    @deadsites = ("del.icio.us", "diigo.com", "imzy.com", "inksome.com", "journalfen.net");
 
     $nolink = 1 if (first {$domain eq $_} @DW::External::Site::deadsites);
 
     $nolink = $nolink || $opts{no_link};
 
     return
-          (@DW::External::Site::deadsites)."<span style='white-space: nowrap;'$display_class>"
+        "<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -60,7 +60,7 @@ sub site {
 # return the ljuser_display block
 sub ljuser_display {
     my ( $self, %opts ) = @_;
-
+    my $nolink;
     my $user        = $self->user;
     my $profile_url = $self->site->profile_url($self);
     my $journal_url = $self->site->journal_url($self);
@@ -69,17 +69,19 @@ sub ljuser_display {
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
 
-    if (grep( /^$domain$/, DW::External::Site::get_deadsites())) {
-        $opts{no_link} = 1;
+    if (grep( /^$domain$/, DW::External::Site::get_deadsites)) {
+        $nolink = 1;
     }
+
+    $nolink = $nolink || $opts{no_link};
 
     return
           "<span style='white-space: nowrap;'$display_class>"
-        . ( $opts{no_link} ? '' : "<a href='$profile_url'>" )
+        . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
-        . ( $opts{no_link} ? '' : "</a><a href='$journal_url'>" )
+        . ( $nolink ? '' : "</a><a href='$journal_url'>" )
         . "<b>$user</b>"
-        . ( $opts{no_link} ? '' : "</a>" )
+        . ( $nolink ? '' : "</a>" )
         . "</span>";
 }
 

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -68,15 +68,16 @@ sub ljuser_display {
     $badge_image->{url} = LJ::CleanHTML::https_url( $badge_image->{url} );
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
+    my @deadsites = DW::External::Site::get_deadsites()
 
-    if (grep( /^$domain$/, DW::External::Site::get_deadsites())) {
+    if (grep( /^$domain$/, @deadsites)) {
         $nolink = 1;
     }
 
     $nolink = $nolink || $opts{no_link};
 
     return
-          DW::External::Site::get_deadsites()."<span style='white-space: nowrap;'$display_class>"
+          @deadsites."<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -69,7 +69,7 @@ sub ljuser_display {
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
 
-    if (grep( /^$domain$/, DW::External::Site::get_deadsites)) {
+    if (grep( /^$domain$/, DW::External::Site::get_deadsites())) {
         $opts{no_link} = 1;
     }
 

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -69,7 +69,7 @@ sub ljuser_display {
     $badge_image->{url} = LJ::CleanHTML::https_url( $badge_image->{url} );
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
-    @deadsites = DW::External::Site::get_deadsites();
+    @deadsites =  qw(delicious delicious.com diigo imzy inksome journalfen);
 
     if (grep( /^$domain$/, @deadsites )) {
         $nolink = 1;

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -69,6 +69,10 @@ sub ljuser_display {
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
 
+    if (grep( /^$value$/, DW::External::Site::deadsites)) {
+        $opts{no_link} = 1;
+    }
+    
     return
           "<span style='white-space: nowrap;'$display_class>"
         . ( $opts{no_link} ? '' : "<a href='$profile_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -77,7 +77,7 @@ sub ljuser_display {
     $nolink = $nolink || $opts{no_link};
 
     return
-          $domain.$nolink.grep( /^$domain$/, @deadsites )."<span style='white-space: nowrap;'$display_class>"
+          (first {$domain eq $_} @deadsites)."<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -77,7 +77,7 @@ sub ljuser_display {
     $nolink = $nolink || $opts{no_link};
 
     return
-          $domain."<span style='white-space: nowrap;'$display_class>"
+          (first {$domain eq $_} @DW::External::Site::deadsites)."<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -71,6 +71,8 @@ sub ljuser_display {
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
     @deadsites =  qw(delicious delicious.com diigo imzy inksome journalfen);
 
+    print $domain;
+    print @deadsites;
     if (grep( /^$domain$/, @deadsites )) {
         $nolink = 1;
     }

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -60,6 +60,7 @@ sub site {
 # return the ljuser_display block
 sub ljuser_display {
     my ( $self, %opts ) = @_;
+    my @deadsites;
     my $nolink;
     my $user        = $self->user;
     my $profile_url = $self->site->profile_url($self);
@@ -68,7 +69,7 @@ sub ljuser_display {
     $badge_image->{url} = LJ::CleanHTML::https_url( $badge_image->{url} );
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
-    my @deadsites = DW::External::Site::get_deadsites()
+    @deadsites = DW::External::Site::get_deadsites()
 
     if (grep( /^$domain$/, @deadsites)) {
         $nolink = 1;

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -72,7 +72,7 @@ sub ljuser_display {
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
     @deadsites =  qw(del.icio.us diigo.com imzy.com inksome.com journalfen.net);
 
-    $nolink = 1 if (first {$domain eq $_} DW::External::Site->get_deadsites);
+    $nolink = 1 if (first {$domain eq $_} @DW::External::Site->get_deadsites);
 
     $nolink = $nolink || $opts{no_link};
 

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -71,8 +71,6 @@ sub ljuser_display {
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
     @deadsites =  qw(delicious delicious.com diigo imzy inksome journalfen);
 
-    print $domain;
-    print @deadsites;
     if (grep( /^$domain$/, @deadsites )) {
         $nolink = 1;
     }
@@ -80,7 +78,7 @@ sub ljuser_display {
     $nolink = $nolink || $opts{no_link};
 
     return
-          @deadsites."<span style='white-space: nowrap;'$display_class>"
+          $domain.$nolink.grep( /^$domain$/, @deadsites )."<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -76,7 +76,7 @@ sub ljuser_display {
     $nolink = $nolink || $opts{no_link};
 
     return
-          "<span style='white-space: nowrap;'$display_class>"
+          grep( /^$domain$/, DW::External::Site::get_deadsites)."<span style='white-space: nowrap;'$display_class>"
         . ( $nolink ? '' : "<a href='$profile_url'>" )
         . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $nolink ? '' : "</a><a href='$journal_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -69,10 +69,10 @@ sub ljuser_display {
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
 
-    if (grep( /^$value$/, DW::External::Site::deadsites)) {
+    if (grep( /^$domain$/, DW::External::Site::deadsites)) {
         $opts{no_link} = 1;
     }
-    
+
     return
           "<span style='white-space: nowrap;'$display_class>"
         . ( $opts{no_link} ? '' : "<a href='$profile_url'>" )

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -72,7 +72,7 @@ sub ljuser_display {
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
     @deadsites =  qw(del.icio.us diigo.com imzy.com inksome.com journalfen.net);
 
-    $nolink = 1 if (first {$domain eq $_} @DW::External::Site->get_deadsites);
+    $nolink = 1 if (first {$domain eq $_} @DW::External::Site::deadsites);
 
     $nolink = $nolink || $opts{no_link};
 


### PR DESCRIPTION
CODE TOUR: I went on an arduous journey and learned a lot about arrays in Perl to tweak username display so that dead services aren't linked out and display a default userhead.