### PR TITLE
Fix overflow of some HTML elements from /latest entries

### DIFF
--- a/ext/dw-nonfree/htdocs/stc/tropo/tropo-base.css
+++ b/ext/dw-nonfree/htdocs/stc/tropo/tropo-base.css
@@ -137,7 +137,7 @@ body {
  * The menu follows the content in the markup source, so we absolutely position it underneath the masthead
  */
 
-nav {
+nav[role="navigation"] {
     position: absolute;
     top: 8.833333em;
     left: 0;
@@ -146,20 +146,20 @@ nav {
     line-height: 2.5em;
     clear: both;
 }
-nav ul {
+nav[role="navigation"] ul {
     margin-left: 0;
 }
-nav ul li {
+nav[role="navigation"] ul li {
     float: left;
     position: relative;
     display: block;
     height: 100%;
     width: 0;
 }
-nav ul > li {
+nav[role="navigation"] ul > li {
     width: auto;
 }
-nav ul li a {
+nav[role="navigation"] ul li a {
     display: block;
     text-decoration: none;
     text-indent: 2em;
@@ -167,17 +167,17 @@ nav ul li a {
 }
 
 /* .hover is a class added by js for the currently hovered/focused menu */
-nav ul li.hover a {
+nav[role="navigation"] ul li.hover a {
     height: 100%;
     width: auto;
 }
-nav ul li.hover a:hover {
+nav[role="navigation"] ul li.hover a:hover {
     cursor: pointer;
 }
-nav ul li ul {
+nav[role="navigation"] ul li ul {
     display: none;
 }
-nav ul li.hover ul {
+nav[role="navigation"] ul li.hover ul {
     display: block;
     position: absolute;
     top: 2.5em;
@@ -188,30 +188,30 @@ nav ul li ul li {
     float: none;
     width: 100%;
 }
-nav ul li ul li a {
+nav[role="navigation"] ul li ul li a {
     text-align: left;
     display: block;
     width: 100%;
 }
-nav .appwidget-search {
+nav[role="navigation"] .appwidget-search {
     text-align: right;
     line-height: 2.1em;
     padding-right: .833333em;
     position: static;
 }
-nav .appwidget-search input#search {
+nav[role="navigation"] .appwidget-search input#search {
     width: 15.5em;
 }
-nav .appwidget-search {
+nav[role="navigation"] .appwidget-search {
     margin-left: 25em;
 }
-nav .appwidget-search {
+nav[role="navigation"] .appwidget-search {
     white-space: nowrap;
 }
-nav .appwidget-search input {
+nav[role="navigation"] .appwidget-search input {
     max-width: 30%;
 }
-nav .appwidget-search select {
+nav[role="navigation"] .appwidget-search select {
     max-width: 20%;
 }
 

--- a/ext/dw-nonfree/htdocs/stc/tropo/tropo-red.css
+++ b/ext/dw-nonfree/htdocs/stc/tropo/tropo-red.css
@@ -63,22 +63,22 @@ a:active,
  * Menu navigation
  */
 
-nav {
+nav[role="navigation"] {
     background: #ddd url(/img/tropo-red/bg_menu_gradient.png) repeat-x;
 }
-nav ul li.topnav a {
+nav[role="navigation"] ul li.topnav a {
     background: transparent url(/img/tropo-red/icon_menu_swirl.png) 0.833333em 0.916667em no-repeat;
     color: #111;
 }
 /* .hover is a class added by js for the currently hovered/focused menu */
-nav ul li.hover a {
+nav[role="navigation"] ul li.hover a {
     background: #f4717a url(/img/tropo-red/icon_menu_swirl_dropdown.png) 0.833333em 0.916667em no-repeat;
     color: #fff;
 }
-nav ul li.hover a:hover {
+nav[role="navigation"] ul li.hover a:hover {
     background-color: #c1272d;
 }
-nav ul li.hover ul {
+nav[role="navigation"] ul li.hover ul {
     background-color: #f4717a;
 }
 
@@ -592,5 +592,3 @@ hr.hr {
 #archive-month .empty {margin: 0;}
 #archive-month .datetime {font-style: italic;}
 #archive-month .tag li {display: inline; list-style:none;}
-
-

--- a/htdocs/scss/skins/_skin-colors.scss
+++ b/htdocs/scss/skins/_skin-colors.scss
@@ -54,7 +54,7 @@ a:hover, a:active {
  * Menu navigation
  */
 
-nav {
+nav[role="navigation"] {
     background-color: $topbar-bg;
 }
 

--- a/htdocs/stc/latest.css
+++ b/htdocs/stc/latest.css
@@ -38,6 +38,8 @@
 
 .latest-entry .event {
     padding: 1em;
+    position: relative;
+    overflow: hidden;
 }
 
 .latest-entry .tags {


### PR DESCRIPTION
CODE TOUR: Some HTML elements were picking up site style CSS due to overly-broad style scoping which led to some elements appearing wildly outside of the container, so this anchors absolutely-positioned items to the entry itself and also narrows the scope of some site styles in the Tropospherical layouts.

(also if someone could test this on an env where /latest works i'd be much obliged)

Closes #3086.