### PR TITLE
Add more wrappers to cut tag elements for styling.

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -609,12 +609,12 @@ TOKEN:
                     # include empty span and div to be filled in on page
                     # load if javascript is enabled
                     $newdata .=
-                          "<span class=\"cut-wrapper\"><span style=\"display: none;\" id=\"span-cuttag_"
+                          "<span style=\"display: none;\" id=\"span-cuttag_"
                         . $journal . "_"
                         . $ditemid . "_"
                         . $cutcount
-                        . "\" class=\"cuttag\"></span></span>";
-                    $newdata .= "<b class=\"cut-open\">(&nbsp;</b><b class=\"cut-text\"><a href=\"$url#cutid$cutcount\">$etext</a></b><b class=\"cut-close\">&nbsp;)</b>";
+                        . "\" class=\"cuttag\"></span>";
+                    $newdata .= "<b>(&nbsp;<a href=\"$url#cutid$cutcount\">$etext</a>&nbsp;)</b>";
                     $newdata .=
                           "<div style=\"display: none;\" id=\"div-cuttag_"
                         . $journal . "_"

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -609,12 +609,12 @@ TOKEN:
                     # include empty span and div to be filled in on page
                     # load if javascript is enabled
                     $newdata .=
-                          "<span style=\"display: none;\" id=\"span-cuttag_"
+                          "<span class=\"cut-wrapper\"><span style=\"display: none;\" id=\"span-cuttag_"
                         . $journal . "_"
                         . $ditemid . "_"
                         . $cutcount
-                        . "\" class=\"cuttag\"></span>";
-                    $newdata .= "<b>(&nbsp;<a href=\"$url#cutid$cutcount\">$etext</a>&nbsp;)</b>";
+                        . "\" class=\"cuttag\"></span></span>";
+                    $newdata .= "<b class=\"cut-open\">(&nbsp;</b><b class=\"cut-text\"><a href=\"$url#cutid$cutcount\">$etext</a></b><b class=\"cut-close\">&nbsp;)</b>";
                     $newdata .=
                           "<div style=\"display: none;\" id=\"div-cuttag_"
                         . $journal . "_"

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -613,8 +613,8 @@ TOKEN:
                         . $journal . "_"
                         . $ditemid . "_"
                         . $cutcount
-                        . "\" class=\"cuttag\"></span></span>";
-                    $newdata .= "<b class=\"cut-open\">(&nbsp;</b><b class=\"cut-text\"><a href=\"$url#cutid$cutcount\">$etext</a></b><b class=\"cut-close\">&nbsp;)</b>";
+                        . "\" class=\"cuttag\"></span>";
+                    $newdata .= "<b class=\"cut-open\">(&nbsp;</b><b class=\"cut-text\"><a href=\"$url#cutid$cutcount\">$etext</a></b><b class=\"cut-close\">&nbsp;)</b></span>";
                     $newdata .=
                           "<div style=\"display: none;\" id=\"div-cuttag_"
                         . $journal . "_"


### PR DESCRIPTION
CODE TOUR: Adds some additional classnamed wrapper elements around the full cut tag and around individual inner parts so that they're all more easily targetable by CSS for the aesthetically minded.

Closes #2979.