### PR TITLE
Hide website link for accounts under ten days old

### DIFF
--- a/cgi-bin/DW/Logic/ProfilePage.pm
+++ b/cgi-bin/DW/Logic/ProfilePage.pm
@@ -535,7 +535,7 @@ sub _basic_info_website {
         $urlname = LJ::ehtml( $urlname || $url );
         if ($url) {
             $ret->[0] = _profile_ml('.label.website');
-            my $spam_time_threshold = (localtime() - (ONE_DAY * 10)) > LJ::mysql_time( $u->timecreate );
+            my $spam_time_threshold = scalar (localtime() - (ONE_DAY * 10)) <= scalar LJ::mysql_time( $u->timecreate );
             if ($spam_time_threshold) {
                 $ret->[1] = { url => $url, text => $urlname };
             } else {

--- a/cgi-bin/DW/Logic/ProfilePage.pm
+++ b/cgi-bin/DW/Logic/ProfilePage.pm
@@ -21,6 +21,8 @@ package DW::Logic::ProfilePage;
 use strict;
 use DW::Countries;
 use DW::Logic::UserLinkBar;
+use Time::Piece;
+use Time::Seconds 'ONE_DAY';
 
 # returns a new profile page object
 sub profile_page {
@@ -533,7 +535,12 @@ sub _basic_info_website {
         $urlname = LJ::ehtml( $urlname || $url );
         if ($url) {
             $ret->[0] = _profile_ml('.label.website');
-            $ret->[1] = { url => $url, text => $urlname };
+            my $spam_time_threshold = (localtime() - (ONE_DAY * 10)) > $u->createdate;
+            if ($spam_time_threshold) {
+                $ret->[1] = { url => $url, text => $urlname };
+            } else {
+                $ret->[1] = "Other people will not see this link on your profile until your account is at least 10 days old.";
+            }
         }
     }
 

--- a/cgi-bin/DW/Logic/ProfilePage.pm
+++ b/cgi-bin/DW/Logic/ProfilePage.pm
@@ -535,7 +535,7 @@ sub _basic_info_website {
         $urlname = LJ::ehtml( $urlname || $url );
         if ($url) {
             $ret->[0] = _profile_ml('.label.website');
-            my $spam_time_threshold = (localtime() - (ONE_DAY * 10)) > $u->createdate;
+            my $spam_time_threshold = (localtime() - (ONE_DAY * 10)) > LJ::mysql_time( $u->timecreate );
             if ($spam_time_threshold) {
                 $ret->[1] = { url => $url, text => $urlname };
             } else {


### PR DESCRIPTION
CODE TOUR: To help discourage spammers from registering accounts here, we want to hide the website link on the profile until the account is ten days old.

Closes #2795.