### PR TITLE
Add more whitelisted embeds

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -106,6 +106,7 @@ my %host_path_match = (
     "www.msnbc.com"    => [ qr!^/msnbc/embedded-video/\w+!, 1 ],
     "my.mail.ru"       => [ qr!^/video/embed/\d+!,          1 ],
 
+    "nekocap.com"      => [ qr!^/view/[a-zA-Z0-9]+/!,                 1 ],
     "ext.nicovideo.jp" => [ qr!^/thumb/!,                             0 ],
     "noisetrade.com"   => [ qr!^/service/widgetv2/!,                  1 ],
     "www.npr.org"      => [ qr!^/templates/event/embeddedVideo\.php!, 1 ],

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -121,6 +121,7 @@ my %host_path_match = (
     "www.redditmedia.com"  => [ qr!^/r/\w+/comments/\w+/\w+/$!,            1 ],
     "www.reverbnation.com" => [ qr!^/widget_code/html_widget/artist_\d+$!, 1 ],
     "rumble.com"           => [ qr!^/embed/[a-zA-Z0-9]+/!,                 1 ],
+    "rutube.ru"            => [ qr!^/play/embed/[0-9]+/$!,                 1 ],
 
     "www.sbs.com.au" => [ qr!/player/embed/!, 0 ]
     ,    # best guess; language parameter before /player may vary

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -71,6 +71,7 @@ my %host_path_match = (
     "diode.zone"          => [ qr!^/videos/embed/[0-9a-fA-F\-]{36}!, 1 ],
     "dotsub.com"          => [ qr!^/media/!,                         1 ],
     "discordapp.com"      => [ qr!^/widget$!,                        1 ],
+    "drive.google.com"    => [ qr!^/file/d/[a-zA-Z0-9]+/preview$!,   1 ],
 
     "episodecalendar.com" => [ qr!^/icalendar/!, 0 ],
 
@@ -100,7 +101,7 @@ my %host_path_match = (
     "www.kickstarter.com" => [ qr!/widget/[a-zA-Z]+\.html$!, 1 ],
 
     "lichess.org" => [ qr!/study/embed/!, 1 ],
-    "loc.gov"     => [ qr!/item/[a-z0-9]+/!, 1],
+    "loc.gov"     => [ qr!/item/[a-z0-9]+!, 1],
 
     "www.mixcloud.com" => [ qr!^/widget/iframe/$!,          1 ],
     "mixstep.co"       => [ qr!^/embed/!,                   1 ],
@@ -123,7 +124,7 @@ my %host_path_match = (
     "www.redditmedia.com"  => [ qr!^/r/\w+/comments/\w+/\w+/$!,            1 ],
     "www.reverbnation.com" => [ qr!^/widget_code/html_widget/artist_\d+$!, 1 ],
     "rumble.com"           => [ qr!^/embed/[a-zA-Z0-9]+/!,                 1 ],
-    "rutube.ru"            => [ qr!^/play/embed/[0-9]+/$!,                 1 ],
+    "rutube.ru"            => [ qr!^/play/embed/[0-9]+$!,                 1 ],
 
     "www.sbs.com.au" => [ qr!/player/embed/!, 0 ]
     ,    # best guess; language parameter before /player may vary

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -136,6 +136,7 @@ my %host_path_match = (
     "streamable.com"     => [ qr!^/[eos]/!,                    1 ],
 
     "embed.ted.com" => [ qr!^/talks/!, 1 ],
+    "twitch.tv"     => [ qr!^/player.twitch.tv/!, 1],
 
     "vid.me"           => [ qr!^/e/!,                              1 ],
     "player.vimeo.com" => [ qr!^/video/\d+$!,                      1 ],

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -100,6 +100,7 @@ my %host_path_match = (
     "www.kickstarter.com" => [ qr!/widget/[a-zA-Z]+\.html$!, 1 ],
 
     "lichess.org" => [ qr!/study/embed/!, 1 ],
+    "loc.gov"     => [ qr!/item/[a-z0-9]+/!, 1],
 
     "www.mixcloud.com" => [ qr!^/widget/iframe/$!,          1 ],
     "mixstep.co"       => [ qr!^/embed/!,                   1 ],

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 113;
+use Test::More tests => 115;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -109,6 +109,7 @@ note("misc");
     test_good_url("https://diode.zone/videos/embed/52a10666-3a18-4e73-93da-e8d3c12c305a");
     test_good_url("http://dotsub.com/media/9db493c6-6168-44b0-89ea-e33a31db48db/e/m");
     test_good_url("https://discordapp.com/widget?id=305444013354254349&theme=dark");
+    test_good_url("https://drive.google.com/file/d/0B65w91gNVFP0OFVsMGxpVmlvRzA/preview");
 
     # E
     test_good_url( "http://episodecalendar.com/icalendar/sampleuser\@example.com/abcde/",

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -172,6 +172,7 @@ note("misc");
 
     # L
     test_good_url("https://lichess.org/study/embed/JYjprYmJ/CeyjnPCj");
+    test_good_url("https://www.loc.gov/item/mbrs01991430/?embed=resources");
 
     test_good_url("https://shad-tkhom.livejournal.com/1244088.html?embed");
     test_bad_url( "https://shad-tkhom.livejournal.com/1244088.html",         "missing embed flag" );

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -222,6 +222,7 @@ note("misc");
 "https://www.reverbnation.com/widget_code/html_widget/artist_299962?widget_id=55&pwc[song_ids]=4189683&context_type=song&pwc[size]=small&pwc[color]=dark"
     );
     test_good_url("https://rumble.com/embed/vr722g/?pub=4");
+    test_good_url("https://rutube.ru/play/embed/7189654");
 
     # S
     test_good_url("http://www.sbs.com.au/yourlanguage//player/embed/id/163111");

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 110;
+use Test::More tests => 113;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -190,6 +190,7 @@ note("misc");
     );
 
     # N
+    test_good_url("https://nekocap.com/view/OUHX8PYzJE?embed=true");
     test_good_url("http://ext.nicovideo.jp/thumb/sm123123123");
     test_good_url("http://ext.nicovideo.jp/thumb/nm123123123");
     test_good_url("http://ext.nicovideo.jp/thumb/123123123");

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -256,6 +256,7 @@ note("misc");
     test_good_url(
 "http://i.cdn.turner.com/cnn/.element/apps/cvp/3.0/swf/cnn_416x234_embed.swf?context=embed&videoId=bestoftv/2012/09/05/exp-tsr-dem-platform-voice-vote.cnn"
     );
+    test_good_url("https://player.twitch.tv/?autoplay=false&video=v582773417");
 
     # V
     test_good_url("https://vid.me/e/v63?stats=1&amp;tools=1");


### PR DESCRIPTION
CODE TOUR: We now allow embeds from Rutube, Nekocap, Twitch, the Library of Congress, and Google Drive.

Closes #2362
Closes #2196
Closes #2892
Closes #2943
Closes #2638