### PR TITLE
Widen work-as select box

### DIFF
--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -204,7 +204,8 @@ sub make_authas_select {
                 name     => 'authas',
                 selected => $authas,
                 class    => 'hideable',
-                id       => 'authas'
+                id       => 'authas',
+                style    => 'width: 100%'
             },
             map { $_, $_ } @list
         );
@@ -219,7 +220,7 @@ sub make_authas_select {
                 . LJ::Lang::ml('web.authas.select.label')
                 . q{</label></div>}
                 . q{<div class='columns small-9 medium-11'><div class='row'>}
-                . q{<div class="columns small-8 medium-5">}
+                . q{<div class="columns small-8 medium-4">}
                 . $menu
                 . q{</div>}
                 . q{<div class='columns small-4 medium-2 end'>}

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -219,7 +219,7 @@ sub make_authas_select {
                 . LJ::Lang::ml('web.authas.select.label')
                 . q{</label></div>}
                 . q{<div class='columns medium-11'><div class='row'>}
-                . q{<div class="columns medium-2">}
+                . q{<div class="columns medium-3">}
                 . $menu
                 . q{</div>}
                 . q{<div class='columns medium-2 end'>}

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -215,14 +215,14 @@ sub make_authas_select {
         }
         else {
             $ret = $foundation
-                ? q{<div class='row collapse'><div class='columns medium-1'><label class='inline'>}
+                ? q{<div class='row collapse'><div class='columns small-3 medium-1'><label class='inline'>}
                 . LJ::Lang::ml('web.authas.select.label')
                 . q{</label></div>}
-                . q{<div class='columns medium-11'><div class='row'>}
-                . q{<div class="columns medium-3">}
+                . q{<div class='columns small-9 medium-11'><div class='row'>}
+                . q{<div class="columns small-8 medium-5">}
                 . $menu
                 . q{</div>}
-                . q{<div class='columns medium-2 end'>}
+                . q{<div class='columns small-4 medium-2 end'>}
                 . LJ::html_submit( undef, $button, { class => "secondary button" } )
                 . q{</div>}
                 . q{</div></div>}


### PR DESCRIPTION
CODE TOUR: Updates the sizing of the work-as select box since text was getting cut off, and adds some classes for handling smaller screens as well.

Closes #2933