### PR TITLE
Properly update inbox count and inbox pagination when items are read/deleted

### DIFF
--- a/cgi-bin/DW/Controller/Inbox.pm
+++ b/cgi-bin/DW/Controller/Inbox.pm
@@ -305,12 +305,21 @@ sub action_handler {
         handle_post( $remote, $action, $view, $itemid, $ids );
     }
 
+    my $getextra = '';
+    if ( $view eq 'singleentry' ) {
+        $getextra = "?view=$view&itemid=$itemid";
+
+    }
+    elsif ( $view ne 'all' ) {
+        $getextra = "?view=$view";
+    }
+
     my $inbox         = $remote->notification_inbox;
     my $display_items = items_by_view( $inbox, $view, $itemid );
     my $last_page     = POSIX::ceil( ( scalar @$display_items ) / $PAGE_LIMIT );
     my $items_html    = render_items( $page, $view, $remote, $display_items, $expand );
     my $folder_html   = render_folders( $remote, $view );
-    my $path          = "$LJ::SITEROOT/inbox/new";
+    my $path          = "/inbox/new$getextra";
     my $pages_html    = DW::Template->template_string( 'components/pagination.tt',
         { current => $page, total_pages => $last_page, path => $path } );
 

--- a/cgi-bin/DW/Controller/Inbox.pm
+++ b/cgi-bin/DW/Controller/Inbox.pm
@@ -307,10 +307,21 @@ sub action_handler {
 
     my $inbox         = $remote->notification_inbox;
     my $display_items = items_by_view( $inbox, $view, $itemid );
+    my $last_page     = POSIX::ceil( ( scalar @$display_items ) / $PAGE_LIMIT );
     my $items_html    = render_items( $page, $view, $remote, $display_items, $expand );
     my $folder_html   = render_folders( $remote, $view );
+    my $path          = "$LJ::SITEROOT/inbox/new";
+    my $pages_html    = DW::Template->template_string( 'components/pagination.tt',
+        { current => $page, total_pages => $last_page, path => $path } );
 
-    return DW::RPC->out( success => { items => $items_html, folders => $folder_html } );
+    return DW::RPC->out(
+        success => {
+            items        => $items_html,
+            folders      => $folder_html,
+            pages        => $pages_html,
+            unread_count => $inbox->unread_count
+        }
+    );
 
 }
 

--- a/htdocs/js/dw/dw-core.js
+++ b/htdocs/js/dw/dw-core.js
@@ -104,6 +104,25 @@ $.fn.throbber = function(jqxhr) {
     return $this;
 };
 
+$.update_inbox = function() {
+    if (!$("#Inbox_Unread_Count, #Inbox_Unread_Count_Menu").length) return;
+
+    $.ajax($.endpoint('esn_inbox'), {
+        'type': "POST",
+        'data': { 'action': 'get_unread_items'},
+        'success': function(resp) {
+            let unread = $("#Inbox_Unread_Count, #Inbox_Unread_Count_Menu");
+            if (!unread.length) return;
+            let unread_count = resp.unread_count? ` (${resp.unread_count})` : "";
+            unread[0].innerHTML = unread_count;
+         }
+    });
+};
+
+if ($("#Inbox_Unread_Count, #Inbox_Unread_Count_Menu").length) {
+    window.setInterval($.update_inbox, 1000 * 60 * 5);
+}
+
 Unique = {
     count: 0,
 

--- a/htdocs/js/jquery.inbox.js
+++ b/htdocs/js/jquery.inbox.js
@@ -149,6 +149,9 @@ function mark_items(e, action, qid) {
     }
     // We've reloaded the view, so set the select-all checkbox to unchecked.
     $('.check_all').prop("checked", false);
+
+    // Update the navbar inbox count
+    $.update_inbox();
 }
 
 // Only load this on the compose page

--- a/htdocs/js/jquery.inbox.js
+++ b/htdocs/js/jquery.inbox.js
@@ -127,6 +127,14 @@ function mark_items(e, action, qid) {
             if (data.success) {
                 $("#inbox_message_list").html(data.success.items);
                 $("#inbox_folders").html(data.success.folders);
+                $(".pagination").html(data.success.pages);
+
+                // Navbar unread count
+                let unread = $("#Inbox_Unread_Count, #Inbox_Unread_Count_Menu");
+                if (!unread.length) return;
+                let unread_count = data.success.unread_count? ` (${data.success.unread_count})` : "";
+                unread[0].innerHTML = unread_count;
+
                 collapsed.forEach(function(id) {
                     var arrow = $("#" + id).siblings('.InboxItem_Controls').find('img.item_expand');
                     arrow.attr({
@@ -149,9 +157,6 @@ function mark_items(e, action, qid) {
     }
     // We've reloaded the view, so set the select-all checkbox to unchecked.
     $('.check_all').prop("checked", false);
-
-    // Update the navbar inbox count
-    $.update_inbox();
 }
 
 // Only load this on the compose page

--- a/views/components/pagination.tt
+++ b/views/components/pagination.tt
@@ -20,7 +20,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [%- IF total_pages > 1 -%]
 <ul class="pagination">
   [% IF current > 1 %]
-    <li class="arrow"><a href="[% dw.create_url( undef, keep_args => 1, args => { page => (current - 1) } ) %]">&laquo;</a></li>
+    <li class="arrow"><a href="[% dw.create_url( path, keep_args => 1, args => { page => (current - 1) } ) %]">&laquo;</a></li>
   [% END %]
 
   [% IF total_pages <= 7 %]
@@ -60,14 +60,14 @@ the same terms as Perl itself.  For a copy of the license, please reference
   [% END %]
 
   [% IF current < total_pages %]
-    <li class="arrow"><a href="[% dw.create_url( undef, keep_args => 1, args => { page => (current + 1) } ) %]">&raquo;</a></li>
+    <li class="arrow"><a href="[% dw.create_url( path, keep_args => 1, args => { page => (current + 1) } ) %]">&raquo;</a></li>
   [% END %]
 </ul>
 [%- END -%]
 
 [%- BLOCK print_pages -%]
   [%- FOREACH page_num = range -%]
-      <li[% IF page_num == current %] class="current" [% END %]><a href="[% dw.create_url( undef, keep_args => 1, args => { page => page_num } ) %]">[% page_num %]</a></li>
+      <li[% IF page_num == current %] class="current" [% END %]><a href="[% dw.create_url( path, keep_args => 1, args => { page => page_num } ) %]">[% page_num %]</a></li>
   [%- END -%]
 [%- END -%]
 


### PR DESCRIPTION
CODE TOUR: More tweaks to the new inbox!

* This adds the 'update the navbar inbox count every five minutes' JS that old pages have into new pages
* Adds proper update of page count and navbar unread count into the new inbox
* The pagination component now takes an optional 'path' variable to explicitly set the path for the pages it generates - if left undefined it'll just use the path from the Request object like it was before.