### PR TITLE
add clear:both to comments on Venture to fix weird overlap issue

### DIFF
--- a/styles/venture/layout.s2
+++ b/styles/venture/layout.s2
@@ -1776,6 +1776,7 @@ $display_topnav_css
     margin: 0;
     padding: 0;
     background-color: $*color_entry_background;
+    clear: both;
     }
 
 .comment .comment-title {


### PR DESCRIPTION
CODE TOUR: Fixes an issue on Venture where long comment threads in the theme style sometimes ended up inappropriately floated.