### PR TITLE
Add nofollow to all user-supplied links on profile

### DIFF
--- a/cgi-bin/DW/Controller/Profile.pm
+++ b/cgi-bin/DW/Controller/Profile.pm
@@ -163,7 +163,7 @@ sub profile_handler {
         if ( $l->{text} ) {
             my $ret = "";
             $ret .= $l->{secimg} if $l->{secimg};
-            $ret .= $l->{url} ? qq(<a href="$l->{url}">$l->{text}</a>) : $l->{text};
+            $ret .= $l->{url} ? qq(<a href="$l->{url}" rel="nofollow">$l->{text}</a>) : $l->{text};
             return $ret;
         }
         elsif ( $l->{email} ) {


### PR DESCRIPTION
CODE TOUR: We're adding the rel="nofollow" attribute to all user-supplied links to try and cut down on spam.

Closes #3066

(Also can someone who can verify their account email on their instance check this for me >_>)