### PR TITLE
Show unsubscribed user link in notification email

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -1416,6 +1416,8 @@ You can:
 
 esn.removedfromcircle.watched.subject=[[who]] has unsubscribed from your journal
 
+esn.show_unsubscribed_journal=[[openlink]]View [[postername]]'s journal[[closelink]]
+
 esn.remove_trust=[[openlink]]Remove access from [[postername]][[closelink]]
 
 esn.remove_watch=[[openlink]]Unsubscribe from [[postername]][[closelink]]

--- a/cgi-bin/LJ/Event/RemovedFromCircle.pm
+++ b/cgi-bin/LJ/Event/RemovedFromCircle.pm
@@ -89,7 +89,7 @@ sub _as_email {
             . $self->format_options(
             $is_html, undef, $vars,
             {
-                'esn.show_unsubscribed_journal' => [ 0, $journal_url ],
+                'esn.show_unsubscribed_journal' => [ 1, $journal_url ],
                 'esn.remove_trust' => [
                     !$u->trusts( $self->fromuser ) ? 0 : 2,
                     "$LJ::SITEROOT/circle/$postername/edit"
@@ -105,7 +105,7 @@ sub _as_email {
             . $self->format_options(
             $is_html, undef, $vars,
             {
-                'esn.show_unsubscribed_journal' => [ 0, $journal_url ],
+                'esn.show_unsubscribed_journal' => [ 1, $journal_url ],
                 'esn.remove_watch' => [
                     !$u->watches( $self->fromuser ) ? 0 : 2,
                     "$LJ::SITEROOT/circle/$postername/edit"

--- a/cgi-bin/LJ/Event/RemovedFromCircle.pm
+++ b/cgi-bin/LJ/Event/RemovedFromCircle.pm
@@ -91,7 +91,7 @@ sub _as_email {
             {
                 'esn.show_unsubscribed_journal' => [ 0, $journal_url ],
                 'esn.remove_trust' => [
-                    !$u->trusts( $self->fromuser ) ? 1 : 2,
+                    !$u->trusts( $self->fromuser ) ? 0 : 2,
                     "$LJ::SITEROOT/circle/$postername/edit"
                 ],
                 'esn.post_entry'   => [ 3, "$LJ::SITEROOT/update" ],
@@ -107,7 +107,7 @@ sub _as_email {
             {
                 'esn.show_unsubscribed_journal' => [ 0, $journal_url ],
                 'esn.remove_watch' => [
-                    !$u->watches( $self->fromuser ) ? 1 : 2,
+                    !$u->watches( $self->fromuser ) ? 0 : 2,
                     "$LJ::SITEROOT/circle/$postername/edit"
                 ],
                 'esn.post_entry'   => [ 3, "$LJ::SITEROOT/update" ],

--- a/cgi-bin/LJ/Event/RemovedFromCircle.pm
+++ b/cgi-bin/LJ/Event/RemovedFromCircle.pm
@@ -45,6 +45,7 @@ my @_ml_strings_en = qw(
     esn.removedfromcircle.watched.subject
     esn.removedfromcircle.trusted.email_text
     esn.removedfromcircle.watched.email_text
+    esn.show_unsubscribed_circle
     esn.remove_trust
     esn.remove_watch
     esn.post_entry

--- a/cgi-bin/LJ/Event/RemovedFromCircle.pm
+++ b/cgi-bin/LJ/Event/RemovedFromCircle.pm
@@ -45,7 +45,7 @@ my @_ml_strings_en = qw(
     esn.removedfromcircle.watched.subject
     esn.removedfromcircle.trusted.email_text
     esn.removedfromcircle.watched.email_text
-    esn.show_unsubscribed_circle
+    esn.show_unsubscribed_journal
     esn.remove_trust
     esn.remove_watch
     esn.post_entry
@@ -89,13 +89,14 @@ sub _as_email {
             . $self->format_options(
             $is_html, undef, $vars,
             {
+                'esn.show_unsubscribed_journal' => [ 0, $journal_url ],
                 'esn.remove_trust' => [
-                    !$u->trusts( $self->fromuser ) ? 0 : 1,
+                    !$u->trusts( $self->fromuser ) ? 1 : 2,
                     "$LJ::SITEROOT/circle/$postername/edit"
                 ],
-                'esn.post_entry'   => [ 2, "$LJ::SITEROOT/update" ],
-                'esn.edit_friends' => [ 3, "$LJ::SITEROOT/manage/circle/edit" ],
-                'esn.edit_groups'  => [ 4, "$LJ::SITEROOT/manage/circle/editfilters" ],
+                'esn.post_entry'   => [ 3, "$LJ::SITEROOT/update" ],
+                'esn.edit_friends' => [ 4, "$LJ::SITEROOT/manage/circle/edit" ],
+                'esn.edit_groups'  => [ 5, "$LJ::SITEROOT/manage/circle/editfilters" ],
             }
             );
     }
@@ -104,13 +105,14 @@ sub _as_email {
             . $self->format_options(
             $is_html, undef, $vars,
             {
+                'esn.show_unsubscribed_journal' => [ 0, $journal_url ],
                 'esn.remove_watch' => [
-                    !$u->watches( $self->fromuser ) ? 0 : 1,
+                    !$u->watches( $self->fromuser ) ? 1 : 2,
                     "$LJ::SITEROOT/circle/$postername/edit"
                 ],
-                'esn.post_entry'   => [ 2, "$LJ::SITEROOT/update" ],
-                'esn.edit_friends' => [ 3, "$LJ::SITEROOT/manage/circle/edit" ],
-                'esn.edit_groups'  => [ 4, "$LJ::SITEROOT/manage/circle/editfilters" ],
+                'esn.post_entry'   => [ 3, "$LJ::SITEROOT/update" ],
+                'esn.edit_friends' => [ 4, "$LJ::SITEROOT/manage/circle/edit" ],
+                'esn.edit_groups'  => [ 5, "$LJ::SITEROOT/manage/circle/editfilters" ],
             }
             );
     }


### PR DESCRIPTION
CODE TOUR: If you're receiving notification emails for when someone has unsubscribed or removed their access, the emails will now give a link to the other user's journal to remind you who they are.

Closes #3060
