### PR TITLE
also rebuild when relevant dw-nonfree files change

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -6,9 +6,13 @@ on:
       - main
     paths:
       - cgi-bin/**
+      - ext/dw-nonfree/cgi-bin/**
       - htdocs/**
+      - ext/dw-nonfree/htdocs/**
       - views/**
+      - ext/dw-nonfree/views/**
       - schemes/**
+      - ext/dw-nonfree/schemes/**
       - src/s2/**
   workflow_dispatch:
 

--- a/.github/workflows/worker-build.yml
+++ b/.github/workflows/worker-build.yml
@@ -6,7 +6,9 @@ on:
       - main
     paths:
       - bin/**
+      - ext/dw-nonfree/bin/**
       - cgi-bin/**
+      - ext/dw-nonfree/cgi-bin/**
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
CODE TOUR: Automated builds of web and worker container images ought to happen when relevant dw-nonfree files change.