### PR TITLE
add a form.button method for use in templates

### DIFF
--- a/cgi-bin/DW/Template/Plugin/FormHTML.pm
+++ b/cgi-bin/DW/Template/Plugin/FormHTML.pm
@@ -105,6 +105,22 @@ All methods which generate an HTML element can accept the following optional arg
 
 =back
 
+=head2 [% form.button( name =... ) %]
+
+Return a generic button for use as a script target. Values are prepopulated by the plugin's datasource.
+
+=cut
+
+sub button {
+    my ( $self, $args ) = @_;
+
+    $args->{class} ||= "button";
+    $args->{type} = "button";
+
+    $self->_process_value_and_label($args);
+    return LJ::html_submit( delete $args->{name}, delete $args->{value}, $args );
+}
+
 =head2 [% form.checkbox( label="A label", id="elementid", name="elementname", .... ) %]
 
 Return a checkbox with a matching label, if provided. Values are prepopulated by the plugin's datasource.

--- a/cgi-bin/LJ/HTMLControls.pm
+++ b/cgi-bin/LJ/HTMLControls.pm
@@ -518,6 +518,7 @@ sub html_submit {
         $disabled = " disabled='disabled'" if $opts->{'disabled'};
         $raw      = " $opts->{'raw'}"      if $opts->{'raw'};
         $type     = 'reset'                if $opts->{type} && $opts->{type} eq 'reset';
+        $type     = 'button'               if $opts->{type} && $opts->{type} eq 'button';
 
         $ehtml = $opts->{'noescape'} ? 0 : 1;
         foreach ( grep { !/^(raw|disabled|noescape|type)$/ } keys %$opts ) {

--- a/views/dev/style-guide.tt
+++ b/views/dev/style-guide.tt
@@ -172,9 +172,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 
   <fieldset><legend>Buttons</legend>
-      <input type="button" class="small button" value=".small.button" /><br>
-      <input type="button" class="button" value="(default) .button" /><br>
-      <input type="button" class="large button" value=".large.button" /><br>
+      [% form.button( class = "small button", value = ".small.button" ) %]<br>
+      [% form.button( class = "button", value = "(default) .button" ) %]<br>
+      [% form.button( class = "large button", value = ".large.button" ) %]<br>
   </fieldset>
 
   <fieldset>


### PR DESCRIPTION
Fixes #3152.

CODE TOUR: Adds a convenience method for developers to add generic form buttons to templates, instead of having to hand-code HTML input tags.