### PR TITLE
Small tweaks to drafts on the new entries page

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1149,6 +1149,12 @@ sub _do_post {
     # post succeeded, time to do some housecleaning
     _persist_props( $auth->{poster}, $form_req, 0 );
 
+    # Clear out a draft
+    if ( $auth->{poster} ) {
+        $auth->{poster}->set_prop( 'entry_draft',      '' );
+        $auth->{poster}->set_prop( 'draft_properties', '' );
+    }
+
     my $render_ret;
     my @links;
 
@@ -1422,12 +1428,6 @@ sub _persist_props {
     return unless $u;
 
     $u->displaydate_check( $form->{update_displaydate} ? 1 : 0 ) unless $is_edit;
-
-    # FIXME:
-    #
-    #                 # Clear out a draft
-    #                 $remote->set_prop('entry_draft', '')
-    #                     if $remote;
 
 }
 

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -181,7 +181,7 @@ postFormInitData.strings = {
                         size = "50"
 
                         labelclass = "hidden"
-                        class = "draft"
+                        class = "draft-autosave"
 
                         placeholder = dw.ml(".subject.placeholder")
                 ) -%]
@@ -441,7 +441,7 @@ postFormInitData.strings = {
         var autoSaveInterval = [% autosave_interval %];
         var savedMsg = [% dw.ml('.draft.autosave', {time => '[[time]]'}) | js %];
         var restoredMsg = [% dw.ml('.draft.restored') | js %]
-        var confirmMsg = [% dw.ml( '.draft.confirm2', { subjectline => draft_subject_raw } ) | js %]
+        var confirmMsg = [% draft_subject_raw.length > 0 ? dw.ml( '.draft.confirm2', { subjectline => draft_subject_raw } ) : dw.ml('.draft.confirm') | js %]
 
         var should_init = [%init_draft %];
 </script>


### PR DESCRIPTION
* fix incorrect class for subject text input
* display correct text on restore dialog when subject is empty
* properly clear out draft userprops on post.

CODE TOUR: Some tweaks to make drafts behave better on the new entry page!
