### PR TITLE
unwiden authas box on non-Foundation pages + retidy

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -609,12 +609,16 @@ TOKEN:
                     # include empty span and div to be filled in on page
                     # load if javascript is enabled
                     $newdata .=
-                          "<span class=\"cut-wrapper\"><span style=\"display: none;\" id=\"span-cuttag_"
+                          "<span class=\"cut-wrapper\">"
+                        . "<span style=\"display: none;\" id=\"span-cuttag_"
                         . $journal . "_"
                         . $ditemid . "_"
                         . $cutcount
                         . "\" class=\"cuttag\"></span>";
-                    $newdata .= "<b class=\"cut-open\">(&nbsp;</b><b class=\"cut-text\"><a href=\"$url#cutid$cutcount\">$etext</a></b><b class=\"cut-close\">&nbsp;)</b></span>";
+                    $newdata .=
+                          "<b class=\"cut-open\">(&nbsp;</b><b class=\"cut-text\">"
+                        . "<a href=\"$url#cutid$cutcount\">$etext</a>"
+                        . "</b><b class=\"cut-close\">&nbsp;)</b></span>";
                     $newdata .=
                           "<div style=\"display: none;\" id=\"div-cuttag_"
                         . $journal . "_"

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -205,7 +205,7 @@ sub make_authas_select {
                 selected => $authas,
                 class    => 'hideable',
                 id       => 'authas',
-                style    => 'width: 100%'
+                style    => $foundation ? 'width: 100%' : '',
             },
             map { $_, $_ } @list
         );


### PR DESCRIPTION
Minor cleanup from recent styling tweaks.

CODE TOUR: #3144 widened the authas box on all pages, but it only wanted to be wider on Foundation-styled pages.