### PR TITLE
Properly clear draft when user chooses not to restore

### DIFF
--- a/htdocs/js/pages/entry/drafts.js
+++ b/htdocs/js/pages/entry/drafts.js
@@ -122,8 +122,7 @@ function initDraft(askToRestore) {
           }
         } else {
             // Clear out their current draft
-            LJDraft.save('');
-            $.post("/__rpc_draft", {clearProperties: 1});
+            $.post("/__rpc_draft", {clearProperties: 1, clearDraft: 1});
         }
    }
 


### PR DESCRIPTION
CODE TOUR: Choosing not to restore an entry draft on the new page would make JS cough up errors. It is now fixed!
