### PR TITLE
Escape JS strings in template, not controller

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -288,7 +288,7 @@ sub new_handler {
         # Here we get the value of the userprop 'draft_properties', containing
         # a frozen Storable string, which we then thaw into a hash by the same
         # name.
-        $draft = LJ::ejs_string( $remote->prop('entry_draft') );
+        $draft = $remote->prop('entry_draft');
         %draft_properties =
             $remote->prop('draft_properties')
             ? %{ Storable::thaw( $remote->prop('draft_properties') ) }
@@ -296,9 +296,6 @@ sub new_handler {
 
         # store raw for later use; will be escaped later
         $draft_subject_raw = $draft_properties{subject};
-
-        %draft_properties = map { $_ => LJ::ejs_string( $draft_properties{$_} ) }
-            qw( subject userpic taglist moodid mood location1 music adultreason commentset commentscr adultcnt editor );
     }
     my $initDraft = 'null';
     if ( $remote && LJ::is_enabled('update_draft') ) {

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -424,24 +424,24 @@ postFormInitData.strings = {
 
 <script>
         // These JS variables contain the contents of the various draft fields.
-        var restoredDraft       = [% draft %];
-        var restoredEditor      = [% draft_properties.editor %] + '';
-        var restoredSubject     = [% draft_properties.subject %];
-        var restoredUserpic     = [% draft_properties.userpic %];
-        var restoredTaglist     = [% draft_properties.taglist %];
-        var restoredMoodID      = [% draft_properties.moodid %];
-        var restoredMood        = [% draft_properties.mood %];
-        var restoredLocation    = [% draft_properties.location1 %];
-        var restoredMusic       = [% draft_properties.music %];
-        var restoredAdultReason = [% draft_properties.adultreason %];
-        var restoredCommentSet  = [% draft_properties.commentset %];
-        var restoredCommentScr  = [% draft_properties.commentscr %];
-        var restoredAdultCnt    = [% draft_properties.adultcnt %];
+        var restoredDraft       = [% draft | js %];
+        var restoredEditor      = [% draft_properties.editor | js %];
+        var restoredSubject     = [% draft_properties.subject | js %];
+        var restoredUserpic     = [% draft_properties.userpic | js %];
+        var restoredTaglist     = [% draft_properties.taglist | js %];
+        var restoredMoodID      = [% draft_properties.moodid | js %];
+        var restoredMood        = [% draft_properties.mood | js %];
+        var restoredLocation    = [% draft_properties.location1 | js %];
+        var restoredMusic       = [% draft_properties.music | js %];
+        var restoredAdultReason = [% draft_properties.adultreason | js %];
+        var restoredCommentSet  = [% draft_properties.commentset | js %];
+        var restoredCommentScr  = [% draft_properties.commentscr | js %];
+        var restoredAdultCnt    = [% draft_properties.adultcnt | js %];
 
-        var autoSaveInterval = [% autosave_interval %];
+        var autoSaveInterval = [% autosave_interval || 3 %];
         var savedMsg = [% dw.ml('.draft.autosave', {time => '[[time]]'}) | js %];
         var restoredMsg = [% dw.ml('.draft.restored') | js %]
         var confirmMsg = [% draft_subject_raw.length > 0 ? dw.ml( '.draft.confirm2', { subjectline => draft_subject_raw } ) : dw.ml('.draft.confirm') | js %]
 
-        var should_init = [%init_draft %];
+        var should_init = [%init_draft || 'null' %];
 </script>


### PR DESCRIPTION
CODE TOUR: Variables for draft autosave weren't getting set to anything when you edited an entry instead of created a new one, which was causing the rest of the JS to choke and die. This fixes that, and sets some defaults in case some things aren't defined.