### PR TITLE
Fix missing JSON import

### DIFF
--- a/cgi-bin/LJ/Event/JournalNewComment/Edited.pm
+++ b/cgi-bin/LJ/Event/JournalNewComment/Edited.pm
@@ -15,6 +15,7 @@ package LJ::Event::JournalNewComment::Edited;
 use strict;
 
 use base 'LJ::Event::JournalNewComment';
+use LJ::JSON;
 
 sub content {
     my ( $self, $target ) = @_;


### PR DESCRIPTION
CODE TOUR: When we cleaned up a bunch of stuff to use off-the-shelf JSON functions, we forgot to import the JSON package into one of the places that need it, whoops.