### PR TITLE
Flip order of header title and module printing

### DIFF
--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -4916,8 +4916,8 @@ function Page::print()
             <div id="header">
                 <div class="inner">
                     """;
-                    $this->print_header();
                     $this->print_module_section("header");
+                    $this->print_header();
     """
                 </div><!-- end header>inner -->
             </div><!-- end header -->


### PR DESCRIPTION
CODE TOUR: When we added the option to put navlinks in the header for all layouts, we also removed code from a bunch of layouts that duplicated what was now in core2. Except... it turns out that it wasn't *quite* a duplicate. The solution was either to put all the duplicate code back in, or change core2 to match what we took out, and the latter seemed tidier.

(The difference was the order in which the header title and header module section printed - core2 had module after title, all the removed code had it before. Now core2 is before, too)