### PR TITLE
Don't impose a text-align on header navlinks in TR

### DIFF
--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -316,7 +316,6 @@ function Page::print_default_stylesheet() {
     if ( $*module_navlinks_section == "header" ) { $navlinks_css = """
         #header > .inner:first-child { padding-bottom: 2em;
             position: relative; }
-        .module-navlinks { text-align:right;}
         .module-navlinks * {
         display: inline !important;
         background:  transparent !important;


### PR DESCRIPTION
CODE TOUR: The CSS for header navlinks in Tabula Rasa was being too opinionated and causing problems with other child layouts, so we fixed it.