### PR TITLE
New Inbox tweaks

### DIFF
--- a/htdocs/js/jquery.inbox.js
+++ b/htdocs/js/jquery.inbox.js
@@ -18,6 +18,7 @@ $('.action_button').click(function(e) {
 
     if (allow) {
         mark_items(e, action);
+        this.blur();
     } else {
         e.preventDefault();
         e.stopPropagation(); 
@@ -144,6 +145,10 @@ function mark_items(e, action, qid) {
                     });
                     $("#" + id).addClass('inbox_collapse');
                 });
+                // We've reloaded the view, so set the select-all checkbox to unchecked.
+                $('.check_all').prop("checked", false);
+                // reset buttons
+                check_selected();
             } else {
                 $(e.target).ajaxtip()
                     .ajaxtip("error", data.error);
@@ -155,8 +160,6 @@ function mark_items(e, action, qid) {
         e.preventDefault();
         e.stopPropagation();
     }
-    // We've reloaded the view, so set the select-all checkbox to unchecked.
-    $('.check_all').prop("checked", false);
 }
 
 // Only load this on the compose page

--- a/views/inbox/index.tt
+++ b/views/inbox/index.tt
@@ -12,13 +12,13 @@
 
 [% BLOCK actions %]
 <div class="header searchhighlight" id="action_row">
-    <div class="checkbox">[% form.checkbox(name = 'check_all', class = 'check_all', value = 'check_all') %]</div>
+    <div class="checkbox">[% form.checkbox(name = 'check_all', class = 'check_all', value = 'check_all', autocomplete = 'off' %]</div>
     <div class="actions">
-        <button name='mark_read' class ='action_button show_unread no-js' data-action='mark_read'>[% dw.ml('widget.inbox.menu.mark_read.btn') %]</button>
-        <button name='mark_unread' class='action_button show_read no-js' data-action='mark_unread'>[% dw.ml('widget.inbox.menu.mark_unread.btn') %]</button>
-        <button name='delete' class='action_button show_read show_unread no-js fi-icon--decorative' data-action='delete'><span class="fi-icon fi-trash" aria-hidden="true"></span> [% dw.ml('.menu.delete.btn') %]</button>
-        <button name='mark_all' class='action_button show_all' data-action='mark_all'>[% dw.ml(mark_all) %]</button>
-        <button name='delete_all' class='action_button show_all fi-icon--decorative' data-action='delete_all'><span class="fi-icon fi-trash" aria-hidden="true"></span> [% dw.ml(delete_all) %]</button>
+        <button name='mark_read' class ='large action_button show_unread no-js' data-action='mark_read'>[% dw.ml('widget.inbox.menu.mark_read.btn') %]</button>
+        <button name='mark_unread' class='large action_button show_read no-js' data-action='mark_unread'>[% dw.ml('widget.inbox.menu.mark_unread.btn') %]</button>
+        <button name='delete' class='large action_button show_read show_unread no-js fi-icon--decorative' data-action='delete'><span class="fi-icon fi-trash" aria-hidden="true"></span> [% dw.ml('.menu.delete.btn') %]</button>
+        <button name='mark_all' class='large action_button show_all' data-action='mark_all'>[% dw.ml(mark_all) %]</button>
+        <button name='delete_all' class='large action_button show_all fi-icon--decorative' data-action='delete_all'><span class="fi-icon fi-trash" aria-hidden="true"></span> [% dw.ml(delete_all) %]</button>
     </div>
     <div class="pages">
         [%- INCLUDE components/pagination.tt

--- a/views/inbox/msg_list.tt
+++ b/views/inbox/msg_list.tt
@@ -11,7 +11,7 @@ LJ_cmtinfo['disableInlineDelete'] = 1;
 [%- ELSE -%]
     [%- FOR m IN messages -%]
         <div class="inbox_item_row [% count % 2 == 1 ? "odd" : "even" %] item_[% m.read %]">
-        <div class="checkbox">[% form.checkbox(name = "check_$m.qid", id = "check_$m.qid", class= "item_checkbox", value = m.qid) %]</div>
+        <div class="checkbox">[% form.checkbox(name = "check_$m.qid", id = "check_$m.qid", class= "item_checkbox", value = m.qid, autocomplete = 'off') %]</div>
         <div class="item">
             <div class="InboxItem_Controls"><a href='[% site.root _ "/inbox/?page=$page&view=$view&$m.bookmark=$m.qid" %]' data-qid ='[% m.qid %]' data-action ='[% m.bookmark %]' class="item_bookmark_action">
                 [% m.bookmark_img %]</a>


### PR DESCRIPTION
* Make action buttons larger so trash icon looks less like a checkbox
* Set 'autocomplete=off' on checkboxes, which keeps Firefox from auto-selecting them on reloads
* Properly reset the action buttons after we've redrawn the message list

CODE TOUR: More little inbox tweaks and fixes!

Closes #3172 