### PR TITLE
fix Facebook embed whitelist regex

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -204,7 +204,7 @@ LJ::Hooks::register_hook(
             return ( 1, 1 )
                 if $uri_path eq '/plugins/video.php'
                 && $parsed_uri->query =~
-                m/^href=https%3A%2F%2Fwww.facebook.com%2F[^%]+%2Fvideos%2F/;
+                m/^(height=\d+&)?href=https%3A%2F%2Fwww.facebook.com%2F[^%]+%2Fvideos%2F/;
         }
 
         if ( $uri_host eq "www.jigsawplanet.com" ) {


### PR DESCRIPTION
CODE TOUR: Facebook appears to have recently added a "height=" argument to the beginning of the query string supplied with their embed codes. This modification fixes the issue in my testing.