### PR TITLE
don't hardcode hover menu widths

### DIFF
--- a/ext/dw-nonfree/htdocs/stc/tropo/tropo-base.css
+++ b/ext/dw-nonfree/htdocs/stc/tropo/tropo-base.css
@@ -184,6 +184,7 @@ nav ul li.hover ul {
     left: 0;
     width: inherit;
     white-space: nowrap;
+    padding-right: 0.5rem;
 }
 nav ul li ul li {
     float: none;

--- a/ext/dw-nonfree/htdocs/stc/tropo/tropo-base.css
+++ b/ext/dw-nonfree/htdocs/stc/tropo/tropo-base.css
@@ -182,7 +182,8 @@ nav ul li.hover ul {
     position: absolute;
     top: 2.5em;
     left: 0;
-    width: 18em;
+    width: inherit;
+    white-space: nowrap;
 }
 nav ul li ul li {
     float: none;

--- a/htdocs/stc/gradation/gradation.css
+++ b/htdocs/stc/gradation/gradation.css
@@ -251,7 +251,8 @@ nav .subnav a {font-weight: normal;
     position: absolute;
     top: 2.5em;
     left: 0;
-    width: 14em;
+    width: inherit;
+    white-space: nowrap;
     background-color: #333;
 }
 #canvas.horizontal-nav nav ul li ul li {


### PR DESCRIPTION
CODE TOUR: I noticed that there were hardcoded widths in the dropdown hover menus (18em in Tropo and 14em in Gradation Horizontal). Letting them adjust to the width of the text looks better, in my opinion.

Before:
<img width="234" alt="Screenshot 2023-07-08 at 4 19 59 PM" src="https://github.com/dreamwidth/dreamwidth/assets/1976742/3ef6c572-bd7e-4bb4-89fd-044639675d4b">

After:
<img width="151" alt="Screenshot 2023-07-08 at 4 20 44 PM" src="https://github.com/dreamwidth/dreamwidth/assets/1976742/8a44af9f-3c2f-4a9f-9861-887aadf34a53">
