### PR TITLE
standardize page title/links for Account Settings et al

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2087,13 +2087,13 @@ menunav.explore.sitesearch=Site and Journal Search
 
 menunav.organize=Organize
 
+menunav.organize.acctsettings=Account Settings
+
 menunav.organize.beta=Test Beta Features
 
-menunav.organize.customizestyle=Customize Style
+menunav.organize.customizejournalstyle=Customize Journal Style
 
 menunav.organize.importcontent=Import Content
-
-menunav.organize.manageaccount=Manage Account
 
 menunav.organize.managecommunities=Manage Communities
 
@@ -2105,7 +2105,7 @@ menunav.organize.managerelationships=Manage Circle
 
 menunav.organize.managetags=Manage Tags
 
-menunav.organize.selectstyle=Select Style
+menunav.organize.selectjournalstyle=Select Journal Style
 
 menunav.read=Read
 

--- a/cgi-bin/DW/Logic/MenuNav.pm
+++ b/cgi-bin/DW/Logic/MenuNav.pm
@@ -115,7 +115,7 @@ sub get_menu_navigation {
             items => [
                 {
                     url     => "$LJ::SITEROOT/manage/settings/",
-                    text    => "menunav.organize.manageaccount",
+                    text    => "menunav.organize.acctsettings",
                     display => $loggedin,
                 },
                 {
@@ -150,12 +150,12 @@ sub get_menu_navigation {
                 },
                 {
                     url     => "$LJ::SITEROOT/customize/",
-                    text    => "menunav.organize.selectstyle",
+                    text    => "menunav.organize.selectjournalstyle",
                     display => $loggedin,
                 },
                 {
                     url     => "$LJ::SITEROOT/customize/options",
-                    text    => "menunav.organize.customizestyle",
+                    text    => "menunav.organize.customizejournalstyle",
                     display => $loggedin,
                 },
                 {

--- a/htdocs/customize/index.bml
+++ b/htdocs/customize/index.bml
@@ -79,11 +79,14 @@ body<=
     }
 
     # would you like to set the site skin instead?
+    $ret .= "<p>";
     if ( $u && $u->is_community ) {
-        $ret .= "<p>" . BML::ml( '.setsiteskin.desc.comm', { aopts => "href='$LJ::SITEROOT/manage/settings/?cat=display#skin'" } ) . "</p>";
+        $ret .= LJ::Lang::ml( '.setstyle.comm' ) . " ";
     } else {
-        $ret .= "<p>" . BML::ml( '.setsiteskin.desc', { aopts => "href='$LJ::SITEROOT/manage/settings/?cat=display#skin'" } ) . "</p>";
+        $ret .= LJ::Lang::ml( '.setstyle.user' ) . " ";
     }
+    $ret .= LJ::Lang::ml( '.setsiteskin', { aopts => "href='$LJ::SITEROOT/manage/settings/?cat=display#skin'" } );
+    $ret .= "</p>";
 
     my $current_theme = LJ::Widget::CurrentTheme->new;
     $headextra .= $current_theme->wrapped_js( page_js_obj => "Customize" );

--- a/htdocs/customize/index.bml.text
+++ b/htdocs/customize/index.bml.text
@@ -1,9 +1,11 @@
 ;; -*- coding: utf-8 -*-
 .btn.nextpage=Customize Selected Theme ->
 
-.setsiteskin.desc=This will set the look and style of your journal. If you'd like to change the way the main site pages look instead, you can do this at the "Site Skin" option on the <a [[aopts]]>Manage Settings</a> page.
+.setstyle.comm=This will set the look and style of your community.
 
-.setsiteskin.desc.comm=This will set the look and style of your community. If you'd like to change the way the main site pages look instead, you can do this at the "Site Skin" option on the <a [[aopts]]>Manage Settings</a> page.
+.setstyle.user=This will set the look and style of your journal.
+
+.setsiteskin=If you would like to change the way the main site pages look instead, you can do this at the "Site Skin" option on the <a [[aopts]]>Account Settings</a> page.
 
 .title=Choose Journal Style
 

--- a/htdocs/manage/settings/index.bml
+++ b/htdocs/manage/settings/index.bml
@@ -437,15 +437,16 @@ body<=
     my $ret = "<div id='settings_page'>";
 
     my ($getextra, $getsep) = ("", "?");
-    $title = $windowtitle = $ML{'.title.self'};
     if ( $u && $u->user ne $remote->user ) {
         $getextra = "?authas=$authas";
         $getsep = "&";
-        $title = BML::ml('.title.comm', { user => $u->ljuser_display });
-        $windowtitle = BML::ml('.title.comm', { user => $u->display_username });
     }
 
+    $title = $windowtitle = LJ::Lang::ml('.title.anon');
     if ($u) {
+        $title = LJ::Lang::ml('.title.page', { user => $u->ljuser_display({ head_size => "24x24" }) });
+        $windowtitle = LJ::Lang::ml('.title.page', { user => $u->display_username });
+
         $ret .= "<div id='authas_select'>";
         $ret .= "<form action='$LJ::SITEROOT/manage/settings/' method='get'>";
         $ret .= LJ::make_authas_select( $remote, { authas => $GET{authas}, showall => ( $given_cat eq "account" ) } );

--- a/htdocs/manage/settings/index.bml.text
+++ b/htdocs/manage/settings/index.bml.text
@@ -178,9 +178,9 @@
 
 .title=Viewing Options
 
-.title.comm=[[user]]'s Account Settings
+.title.anon=Account Settings
 
-.title.self=My Account Settings
+.title.page=Account Settings for [[user]]
 
 .user=View notifications for user:
 

--- a/views/site/index.tt
+++ b/views/site/index.tt
@@ -73,7 +73,7 @@
  <dl>
   <dt>[% '.maplinks.title.manage-account' | ml( sitename = site.nameshort ) %]</dt>
   <dd><ul>
-   <li><a href='/manage/settings/'>[% '.maplinks.manage-settings' | ml %]</a></li>
+   <li><a href='/manage/settings/'>[% '.maplinks.account-settings' | ml %]</a></li>
    <li><a href='/inbox/'>[% '.maplinks.inbox' | ml %]</a></li>
    <li><a href='/shop'>[% '.maplinks.upgrade' | ml %]</a></li>
    <li><a href='/changepassword'>[% '.maplinks.changepassword' | ml %]</a></li>
@@ -85,8 +85,8 @@
  <dl>
   <dt>[% '.maplinks.title.customize' | ml( sitename = site.nameshort ) %]</dt>
   <dd><ul>
-   <li><a href='/customize/'>[% '.maplinks.selectstyle' | ml %]</a></li>
-   <li><a href='/customize/options'>[% '.maplinks.customizestyle' | ml %]</a></li>
+   <li><a href='/customize/'>[% '.maplinks.selectjournalstyle' | ml %]</a></li>
+   <li><a href='/customize/options'>[% '.maplinks.customizejournalstyle' | ml %]</a></li>
    <li><a href='/customize/options?group=linkslist'>[% '.maplinks.manage-linkslist' | ml %]</a></li>
    <li><a href='/support/faqbrowse?faqcat=styles'>[% '.maplinks.about-customizing' | ml %]</a></li>
    <li><a href='/customize/advanced/'>[% '.maplinks.advanced-customization' | ml %]</a></li>

--- a/views/site/index.tt.text
+++ b/views/site/index.tt.text
@@ -7,6 +7,8 @@
 
 .maplinks.aboutus=About Us
 
+.maplinks.account-settings=Account Settings
+
 .maplinks.advanced-customization=Advanced Customization
 
 .maplinks.beta=Test Beta Features
@@ -33,7 +35,7 @@
 
 .maplinks.create-poll=Create a poll
 
-.maplinks.customizestyle=Customize Style
+.maplinks.customizejournalstyle=Customize Journal Style
 
 .maplinks.directory=Search the Directory
 
@@ -77,8 +79,6 @@
 
 .maplinks.manage-readlist=Manage Circle
 
-.maplinks.manage-settings=Manage Settings
-
 .maplinks.manage-tags=Manage Tags
 
 .maplinks.manage-userpics=Manage Icons
@@ -103,7 +103,7 @@
 
 .maplinks.search.site=Site search
 
-.maplinks.selectstyle=Select Style
+.maplinks.selectjournalstyle=Select Journal Style
 
 .maplinks.sitestats=Site Statistics
 


### PR DESCRIPTION
CODE TOUR: Reduce confusion by using "Account Settings" consistently to refer to the Account Settings page, and include the word "Journal" when choosing or customizing journal styles.

Fixes #2673