### PR TITLE
[#3189] show tag name instead of tag id

### DIFF
--- a/cgi-bin/DW/Controller/LatestFeed.pm
+++ b/cgi-bin/DW/Controller/LatestFeed.pm
@@ -98,7 +98,7 @@ sub generate_vars {
     my ( $type, $max, $fmt, $feed, $tag ) =
         ( $get->{type}, $get->{max}, $get->{fmt}, $get->{feed}, $get->{tag} );
 
-    my $tagname = $tag;
+    my $tagname = LJ::get_interest($tag);    # this function needs a better name
     my $now     = time();
 
     # if they want a format we don't support ... FIXME: implement all formats


### PR DESCRIPTION
CODE TOUR: When filtering /latest by tag, show the tag name at the top of the page, not the tag id.

Fixes #3189.