### PR TITLE
[#3197] explicitly include LJ::Stats

### DIFF
--- a/cgi-bin/DW/Controller/Search/Interests.pm
+++ b/cgi-bin/DW/Controller/Search/Interests.pm
@@ -22,7 +22,9 @@ use warnings;
 use DW::Routing;
 use DW::Template;
 use DW::Controller;
+
 use LJ::Global::Constants;
+use LJ::Stats;
 
 DW::Routing->register_string( '/interests', \&interest_handler, app => 1 );
 

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -3784,7 +3784,7 @@ sub _print_quickreply_link {
     # FIXME: I THINK the next line is incoherent on reading/network pages. -NF
     $onclick = "" if $page->{'_u'}->does_not_allow_comments_from_non_access($remote);
 
-    $replyurl = LJ::ehtml( $replyurl );
+    $replyurl = LJ::ehtml($replyurl);
 
     $S2::pout->("<a $onclick href='$replyurl' $opt_class>$linktext</a>");
 }


### PR DESCRIPTION
Why this is only now a problem, when the file hasn't been edited since 2019, is a mystery for another day.

CODE TOUR: fix code loading error that broke the popular interests page

Fixes #3197.