### PR TITLE
put authas select back in /register

### DIFF
--- a/views/register.tt
+++ b/views/register.tt
@@ -62,13 +62,19 @@ the same terms as Perl itself. For a copy of the license, please reference
   [% END %]
 
 [%- ELSE -%]
+  [% authas_form %]
+
+  [% IF u.email_status == "A" %]
+<p>[% '.error.useralreadyvalidated' | ml( user => u.ljuser_display ) %]</p>
+  [% ELSE %]
 
 <p>[% '.ask.body' | ml( email => u.email_raw ) %]</p>
-<form action='[% site.root %]/register' method='post'>
+<form action='[% dw.create_url( undef, keep_args => 1 ) %]' method='post'>
   [% dw.form_auth %]
   <blockquote>
     [% form.submit( name = "action:send", value = dw.ml( '.ask.button' ) ) %]
   </blockquote>
 </form>
 
+  [% END %]
 [%- END -%]


### PR DESCRIPTION
Wow, I really messed up this conversion!

1. I didn't realize that email addresses for communities were still an ongoing concern? I had removed the authas selection form, but it turns out to still be necessary sometimes.

2. Furthermore, DW::Controller won't let you use both authas and anonymous. But the only part of the page code that actually didn't require you to be logged in was the /confirm path, and it's probably actually not great to let that work logged out, so I removed the anonymous option instead. If THAT needs to come back later, it'll have to be moved into a separate controller from the rest of /register.

3. The cherry on top was when I realized I had accidentally passed the controller options to register_string instead of controller, so the options weren't even being enabled! I can't believe I didn't notice that when I was testing the initial conversion.

CODE TOUR: add the authas select menu back to /register