### PR TITLE
Be slightly more lenient about removing HTML links from userbios

### DIFF
--- a/cgi-bin/DW/Hooks/SpamCheck.pm
+++ b/cgi-bin/DW/Hooks/SpamCheck.pm
@@ -38,7 +38,7 @@ LJ::Hooks::register_hook(
             return unless defined $item;        # don't waste time iterating over undefined items
 
             foreach my $domain (@blocked_domains) {
-                if ( $item =~ m|\b${domain}\b| ) {
+                if ( $item =~ m|\b${domain}\b|i ) {
                     $u->set_suspended( $system,
                         "auto-suspend for matching domain blocklist: $domain in $loc" );
                     return 1;

--- a/cgi-bin/DW/Logic/ProfilePage.pm
+++ b/cgi-bin/DW/Logic/ProfilePage.pm
@@ -715,7 +715,7 @@ sub bio {
             $ret =~ s!\n!<br />!g;
         }
         else {
-            LJ::CleanHTML::clean_userbio( \$ret, !$u->is_validated );
+            LJ::CleanHTML::clean_userbio( \$ret, $u->email_status eq "N" );
         }
 
         LJ::EmbedModule->expand_entry( $u, \$ret );


### PR DESCRIPTION
The is_validated method returns false for any email_status that isn't "A", but "T" means transitioning from one validated email to another, so we should allow that and only strip links if the email_status is "N".

CODE TOUR: Be slightly more lenient about removing HTML links from userbios when the user/admin hasn't confirmed the account's email address.