### PR TITLE
[#3092] new timeupdate_public column for stats use

### DIFF
--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -4213,8 +4213,15 @@ q{INSERT INTO media_versions (userid, mediaid, versionid, width, height, filesiz
         }
 
         if ( column_type( 'userusage', 'timecheck' ) ) {
-            do_alter( 'user',
+            do_alter( 'userusage',
                 'ALTER TABLE userusage DROP COLUMN timecheck, ALGORITHM=INPLACE, LOCK=NONE' );
+        }
+
+        if ( table_relevant("userusage") && column_type( "userusage", "timeupdate_public" ) eq '' )
+        {
+            do_alter( 'userusage',
+                      "ALTER TABLE userusage ADD COLUMN timeupdate_public DATETIME, "
+                    . "ADD INDEX (timeupdate_public)" );
         }
     }
 );

--- a/cgi-bin/DW/Controller/Stats.pm
+++ b/cgi-bin/DW/Controller/Stats.pm
@@ -92,9 +92,9 @@ sub main_handler {
         if ( LJ::is_enabled('stats-recentupdates') ) {
 
             $sth = $dbr->prepare(
-                "SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE
-                u.userid=uu.userid AND uu.timeupdate > DATE_SUB(NOW(), INTERVAL 30 DAY)
-                AND u.journaltype = ? ORDER BY uu.timeupdate DESC LIMIT 20"
+                "SELECT u.userid, uu.timeupdate_public AS 'timeupdate' FROM user u, userusage uu
+                WHERE u.userid=uu.userid AND uu.timeupdate_public > DATE_SUB(NOW(), INTERVAL 30 DAY)
+                AND u.journaltype = ? ORDER BY uu.timeupdate_public DESC LIMIT 20"
             );
 
             $sth->execute('P');

--- a/cgi-bin/DW/Widget/RecentlyActiveComms.pm
+++ b/cgi-bin/DW/Widget/RecentlyActiveComms.pm
@@ -39,9 +39,10 @@ sub render_body {
 
     # prep the stats we're interested in using here
 
-    $sth = $dbr->prepare(
-"SELECT u.user, u.name, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate > DATE_SUB(NOW(), INTERVAL 30 DAY) AND u.journaltype = 'C' ORDER BY uu.timeupdate DESC LIMIT 10"
-    );
+    $sth =
+        $dbr->prepare( "SELECT u.user, u.name, uu.timeupdate_public FROM user u, userusage uu"
+            . " WHERE u.userid=uu.userid AND uu.timeupdate_public > DATE_SUB(NOW(), INTERVAL 30 DAY)"
+            . " AND u.journaltype = 'C' ORDER BY uu.timeupdate_public DESC LIMIT 10" );
     $sth->execute;
 
     $ret .= "<h2>" . $class->ml('widget.comms.recentactive') . "</h2>";

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -1721,10 +1721,15 @@ sub postevent {
             if %logprops;
     }
 
-    $dbh->do(
-        "UPDATE userusage SET timeupdate=NOW(), lastitemid=$jitemid " . "WHERE userid=$ownerid" )
+    $dbh->do("UPDATE userusage SET timeupdate=NOW(), lastitemid=$jitemid WHERE userid=$ownerid")
         unless $flags->{'notimeupdate'};
     LJ::MemCache::set( [ $ownerid, "tu:$ownerid" ], pack( "N", time() ), 30 * 60 );
+
+    # update timeupdate_public for stats page
+    if ( $security eq 'public' ) {
+        $dbh->do("UPDATE userusage SET timeupdate_public=NOW() WHERE userid=$ownerid")
+            unless $flags->{'notimeupdate'};
+    }
 
     # argh, this is all too ugly.  need to unify more postpost stuff into async
     $u->invalidate_directory_record;


### PR DESCRIPTION
Add the column, populate it in the protocol, and use it instead of timeupdate when calculating %accounts_updated in Stats.pm.

CODE TOUR: construct the list of users on /stats who have recently updated by order of most recent public entry instead of most recent entry, period.

Fixes #3092.