### PR TITLE
new page /dev/embeds for documenting whitelisted embed domains

### DIFF
--- a/cgi-bin/DW/Controller/Dev.pm
+++ b/cgi-bin/DW/Controller/Dev.pm
@@ -26,9 +26,9 @@ use DW::Formats;
 
 use LJ::JSON;
 
+DW::Routing->register_string( '/dev/embeds',      \&embeds_handler,      app => 1 );
+DW::Routing->register_string( '/dev/formats',     \&formats_handler,     app => 1 );
 DW::Routing->register_string( '/dev/style-guide', \&style_guide_handler, app => 1 );
-
-DW::Routing->register_string( '/dev/formats', \&formats_handler, app => 1 );
 
 if ($LJ::IS_DEV_SERVER) {
     DW::Routing->register_string( '/dev/tests/index', \&tests_index_handler, app => 1 );
@@ -101,6 +101,15 @@ sub formats_handler {
             aliases        => \%aliases,
         }
     );
+}
+
+sub embeds_handler {
+    my ( $ok, $rv ) = controller( anonymous => 1 );
+    return $rv unless $ok;
+
+    my $embed_domains = LJ::Hooks::run_hook('list_iframe_embed_domains');
+
+    return DW::Template->render_template( 'dev/embeds.tt', { embed_domains => $embed_domains } );
 }
 
 sub tests_index_handler {

--- a/cgi-bin/DW/Controller/Dev.pm
+++ b/cgi-bin/DW/Controller/Dev.pm
@@ -108,8 +108,33 @@ sub embeds_handler {
     return $rv unless $ok;
 
     my $embed_domains = LJ::Hooks::run_hook('list_iframe_embed_domains');
+    my $domain_groups = {};
 
-    return DW::Template->render_template( 'dev/embeds.tt', { embed_domains => $embed_domains } );
+    my $tld = sub {
+        my ($dom) = @_;
+        my $idx = ( $dom =~ /\.com?\.\w+$/ ) ? -3 : -2;
+        return [ split /\./, $dom ]->[$idx];
+    };
+
+    foreach my $dom (@$embed_domains) {
+        my $key;
+        my $chr_start = substr( uc $tld->($dom), 0, 1 );
+
+        if ( $chr_start =~ /\d/ ) {
+            $key = '0 - 9';
+        }
+        elsif ( $chr_start =~ /[A-Z]/ ) {
+            $key = $chr_start;
+        }
+        else {
+            $key = '(Other)';
+        }
+
+        $domain_groups->{$key} //= [];
+        push @{ $domain_groups->{$key} }, $dom;
+    }
+
+    return DW::Template->render_template( 'dev/embeds.tt', { embed_domains => $domain_groups } );
 }
 
 sub tests_index_handler {

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -269,9 +269,13 @@ LJ::Hooks::register_hook(
     'list_iframe_embed_domains',
     sub {
         my @list = ( keys %host_path_match, keys %complex_match );
-        my $dom  = sub { [ split /\./, $_[0] ]->[-2] };
+        my $tld  = sub {
+            my ($dom) = @_;
+            my $idx = ( $dom =~ /\.com?\.\w+$/ ) ? -3 : -2;
+            return [ split /\./, $dom ]->[$idx];
+        };
 
-        my $sort_domain = sub { $dom->($a) cmp $dom->($b) || $a cmp $b };
+        my $sort_domain = sub { $tld->($a) cmp $tld->($b) || $a cmp $b };
         return [ sort $sort_domain @list ];
     }
 );

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -265,4 +265,15 @@ LJ::Hooks::register_hook(
     }
 );
 
+LJ::Hooks::register_hook(
+    'list_iframe_embed_domains',
+    sub {
+        my @list = ( keys %host_path_match, keys %complex_match );
+        my $dom  = sub { [ split /\./, $_[0] ]->[-2] };
+
+        my $sort_domain = sub { $dom->($a) cmp $dom->($b) || $a cmp $b };
+        return [ sort $sort_domain @list ];
+    }
+);
+
 1;

--- a/views/dev/embeds.tt
+++ b/views/dev/embeds.tt
@@ -1,0 +1,35 @@
+[%# Generate a user-visible list of whitelisted embed domains.
+  #
+  # Authors:
+  #     Jen Griffin <kareila@livejournal.com>
+  #
+  # Copyright (c) 2023 by Dreamwidth Studios, LLC.
+  #
+  # This program is free software; you may redistribute it and/or modify it under
+  # the same terms as Perl itself.  For a copy of the license, please reference
+  # 'perldoc perlartistic' or 'perldoc perlgpl'.
+-%]
+
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[%- sections.title = "Supported Domains for Site Embed Codes" -%]
+
+<p>[% site.nameshort %] curates a whitelist of allowed domains and formats for embed codes shared from other sites.</p>
+
+<p>If the site you are trying to use is included on this list, but it doesn't seem to be working in your journal, please <a href="/support/submit">open a support request</a> so we can investigate. You should include in your support request the exact code you are trying to use, so that we can compare it with what our code is expecting.</p>
+
+<p>If the site you are trying to use is <em>not</em> included on this list, we might be able to include it in the future! Look at the embed code you are trying to use and:</p>
+
+<ul>
+<li style="margin-bottom: 1em;">... if it uses &lt;script&gt; tags, sorry! We can't allow embed codes that use script tags, for security reasons.</li>
+
+<li style="margin-bottom: 1em;">... if it does <em>not</em> use &lt;script&gt; tags (or you're not sure either way), you can send the code to us in a <a href="/support/submit">support request</a>. The support team will forward your request to the development team.</li>
+</ul>
+
+<h2>Currently Supported Domains</h2>
+
+<ol>
+[% FOREACH domain IN embed_domains %]
+    <li>[% domain %]</li>
+[% END %]
+</ol>

--- a/views/dev/embeds.tt
+++ b/views/dev/embeds.tt
@@ -26,10 +26,13 @@
 <li style="margin-bottom: 1em;">... if it does <em>not</em> use &lt;script&gt; tags (or you're not sure either way), you can send the code to us in a <a href="/support/submit">support request</a>. The support team will forward your request to the development team.</li>
 </ul>
 
-<h2>Currently Supported Domains</h2>
+<h2 style="margin: 1em 0;">Currently Supported Domains</h2>
 
-<ol>
-[% FOREACH domain IN embed_domains %]
+[% FOREACH dom_key IN embed_domains.keys.sort %]
+<h4>[% dom_key %]</h4>
+<ul>
+  [% FOREACH domain IN embed_domains.$dom_key %]
     <li>[% domain %]</li>
+  [% END %]
+</ul>
 [% END %]
-</ol>


### PR DESCRIPTION
CODE TOUR: Ever wondered which domains were allowed for embed codes? Wonder no more!

I've been discouraged for years from writing a FAQ that included a list of the whitelisted domains because I knew it would be impossible to keep up to date.

I finally had a brainwave (inspired by the documentation @nfagerlund did for /dev/formats) and now we will have a page we can refer people to which will always have the most current list of supported sites.