### PR TITLE
clean up interest count underflow during daily stats tasks

### DIFF
--- a/bin/maint/stats.pl
+++ b/bin/maint/stats.pl
@@ -69,6 +69,12 @@ $maint{'genstats'} = sub {
 
                 return {} unless LJ::is_enabled('interests-popular');
 
+                # first, look for interest counts that have overflowed
+                # and reset them to zero so they don't appear here
+                my $dbh = LJ::Stats::get_db("dbh");
+                $dbh->do( "UPDATE interests SET intcount=0 WHERE intcount>?", undef, 16777200 );
+                die $dbh->errstr if $dbh->err;
+
                 # see what the previous min was, then subtract 20% of max from it
                 my ( $prev_min, $prev_max ) =
                     $db->selectrow_array( "SELECT MIN(statval), MAX(statval) "

--- a/cgi-bin/DW/Controller/Search/Interests.pm
+++ b/cgi-bin/DW/Controller/Search/Interests.pm
@@ -85,7 +85,8 @@ sub interest_handler {
             };
         }
         $rv->{pop_cloud} = LJ::tag_cloud( \%interests );
-        $rv->{pop_ints}  = [ sort { $b->{value} <=> $a->{value} } values %interests ]
+        $rv->{pop_ints} =
+            [ sort { $b->{value} <=> $a->{value} || $a->{eint} cmp $b->{eint} } values %interests ]
             if %interests;
         return DW::Template->render_template( 'interests/popular.tt', $rv );
     }


### PR DESCRIPTION
Makes sense to do it at the same time the popular interests are tallied.

Also add secondary alpha sort to the popular interests list.

Closes #1839. Closes #3054. Closes #3106.

CODE TOUR: The popular interests with ridiculously high numbers are bogus and should be zeroed out whenever they appear.