### PR TITLE
require confirmation of email before allowed to post entries

### DIFF
--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -1278,6 +1278,9 @@ sub postevent {
         "You must have an authenticated email address in order to post to another account" )
         unless $u->equals($uowner) || $u->{'status'} eq 'A' || $flags->{'nomod'};
 
+    return fail( $err, 155, "You must confirm your email address before posting." )
+        if $u->{'status'} eq 'N';
+
     # post content too large
     # NOTE: requires $req->{event} be binary data, but we've already
     # removed the utf-8 flag in the XML-RPC path, and it never gets


### PR DESCRIPTION
CODE TOUR: A user who has never confirmed their email address will now see an error when they try to post an entry, saying that confirmation is required.

Adding this single line to the protocol seems to do the trick in my testing.

Fixes #3025.