### PR TITLE
link to full logout page from entry post/edit/delete success links

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1219,6 +1219,10 @@ sub _do_post {
             {
                 url       => "$LJ::SITEROOT/editjournal",
                 ml_string => '.links.manageentries',
+            },
+            {
+                url       => "$LJ::SITEROOT/logout",
+                ml_string => '.links.logout',
             }
             );
 
@@ -1344,6 +1348,10 @@ sub _do_edit {
             {
             url       => "$LJ::SITEROOT/editjournal",
             ml_string => '.links.manageentries',
+            },
+            {
+            url       => "$LJ::SITEROOT/logout",
+            ml_string => '.links.logout',
             };
 
     }
@@ -1382,6 +1390,10 @@ sub _do_edit {
             {
                 url       => "$LJ::SITEROOT/editjournal",
                 ml_string => '.links.manageentries',
+            },
+            {
+                url       => "$LJ::SITEROOT/logout",
+                ml_string => '.links.logout',
             }
             );
 

--- a/views/entry/success.tt.text
+++ b/views/entry/success.tt.text
@@ -22,6 +22,8 @@
 
 .links.manageentries=Manage your journal entries
 
+.links.logout=Log out of your account
+
 .extradata.subj=The entry was posted with the following subject: 
 
 .extradata.subject.no_subject=(no subject)


### PR DESCRIPTION
CODE TOUR: add /logout link to entry success links

I considered Nick's suggestions in #2553 but I didn't like the idea of putting the logout link anywhere near the settings page, because (a) crowded and (b) the Manage Logins page prominently linked there already has logout form buttons. Putting it right next to the sitewide logout button didn't make sense to me, either.

So I thought, when would someone be likely to want to be _prompted_ to log out of the site? And the answer that came to me was... after posting (or editing, or deleting) an entry. So this adds it to the success links for the beta version of the entry form.

Closes #2553, unless someone strenuously objects to my reasoning.