### PR TITLE
allow fields in currents module to be cleared on edit

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -791,8 +791,7 @@ sub _form_to_backend {
     my $props = $req->{props};
 
     while ( my ( $formname, $propname ) = each %form_to_props ) {
-        $props->{$propname} = $post->{$formname}
-            if defined $post->{$formname};
+        $props->{$propname} = $post->{$formname} // '';
     }
     $props->{taglist}         = $post->{taglist} if defined $post->{taglist};
     $props->{picture_keyword} = $post->{prop_picture_keyword}


### PR DESCRIPTION
CODE TOUR: fixes a glitch with the beta entry form where fields in the Currents module couldn't be edited to be blank after being saved with a non-blank value.

#2932 reported this as a problem with the Location field, but it affected all fields in the Currents module - empty fields were simply ignored on post.

Fixes #2932.