### PR TITLE
fix issues with reply form textareas on /support/see_request

### DIFF
--- a/htdocs/stc/support.css
+++ b/htdocs/stc/support.css
@@ -18,9 +18,13 @@
     font-size: 85%;
 }
 
-.request-form input, .request-form textarea {
+.request-form input {
     display: inline;
     width: auto;
+}
+
+.request-form textarea {
+    width: 95%;
 }
 
 .request-form label.checkboxlabel {

--- a/views/support/request/form.tt
+++ b/views/support/request/form.tt
@@ -79,7 +79,7 @@ END -%]
 -%]
 </li>
 <li>
-<p style='padding-left: 12em'>[%- '.no.html.allowed3' | ml -%]</p></li>
+<p style='padding: 0 6em'>[%- '.no.html.allowed3' | ml -%]</p></li>
 </ul>
 </fieldset>
 


### PR DESCRIPTION
CODE TOUR: make the support request reply form more accessible on smaller screens.

Closes #2921.