### PR TITLE
check style for width and height when parsing embeds

### DIFF
--- a/cgi-bin/LJ/EmbedModule.pm
+++ b/cgi-bin/LJ/EmbedModule.pm
@@ -318,6 +318,21 @@ sub _extract_num_unit {
     return ( $num, "%" );
 }
 
+sub _extract_style_keyvals {
+    my $style_arg = $_[0];
+    return unless $style_arg;
+
+    my @stylevals = grep { $_ } map { LJ::trim($_) } split /;/, $style_arg;
+    return unless @stylevals;
+
+    my %styles;
+    foreach my $s (@stylevals) {
+        my ( $key, $val ) = split /\s*:\s*/, $s;
+        $styles{$key} = $val;
+    }
+    return %styles;
+}
+
 # Returns a hash of link text, url
 # Provides the fallback link text for when host API has not been contacted for title
 # Currently handles: YouTube, Vimeo
@@ -563,10 +578,10 @@ sub module_iframe_tag {
                 }
 
                 # parse the style attribute for width and height
-                if ( my $style = $attr->{style} ) {
-                    unless ($width) {
+                if ( my %style = _extract_style_keyvals( $attr->{style} ) ) {
+                    if ( $style{width} && !$width ) {
                         my ( $style_width, $style_width_unit ) =
-                            ( $style =~ /width:\s+(\d+)([^;"'\s])/ );
+                            ( $style{width} =~ /^(\d+)(.*)/ );
                         if ($style_width) {
                             $style_width_unit = "%"
                                 if $style_width_unit && $style_width_unit =~ /^%/;
@@ -576,9 +591,9 @@ sub module_iframe_tag {
                         }
                     }
 
-                    unless ($height) {
+                    if ( $style{height} && !$height ) {
                         my ( $style_height, $style_height_unit ) =
-                            ( $style =~ /height:\s+(\d+)([^;"'\s])/ );
+                            ( $style{height} =~ /^(\d+)(.*)/ );
                         if ($style_height) {
                             $style_height_unit = "%"
                                 if $style_height_unit && $style_height_unit =~ /^%/;

--- a/cgi-bin/LJ/EmbedModule.pm
+++ b/cgi-bin/LJ/EmbedModule.pm
@@ -562,7 +562,33 @@ sub module_iframe_tag {
                     }
                 }
 
-                my $flashvars = $attr->{flashvars};
+                # parse the style attribute for width and height
+                if ( my $style = $attr->{style} ) {
+                    unless ($width) {
+                        my ( $style_width, $style_width_unit ) =
+                            ( $style =~ /width:\s+(\d+)([^;"'\s])/ );
+                        if ($style_width) {
+                            $style_width_unit = "%"
+                                if $style_width_unit && $style_width_unit =~ /^%/;
+                            $style_width_unit = "" if $style_width_unit && $style_width_unit ne "%";
+                            $width            = $style_width;
+                            $width_unit       = $style_width_unit;
+                        }
+                    }
+
+                    unless ($height) {
+                        my ( $style_height, $style_height_unit ) =
+                            ( $style =~ /height:\s+(\d+)([^;"'\s])/ );
+                        if ($style_height) {
+                            $style_height_unit = "%"
+                                if $style_height_unit && $style_height_unit =~ /^%/;
+                            $style_height_unit = ""
+                                if $style_height_unit && $style_height_unit ne "%";
+                            $height      = $style_height;
+                            $height_unit = $style_height_unit;
+                        }
+                    }
+                }
 
                 if ( $embeddable_tags{$tag} ) {
                     my $src;


### PR DESCRIPTION
CODE TOUR: more accurate sizing of embed codes from other sites.

I was looking at #2163 and trying to figure out how the embed module parsed width and height... the answer is that if the width and height are in a style tag, it wasn't even trying. (I guess because that code predates CSS styles?)

This should fix #2163 specifically as well as embed display weirdnesses in general.