### PR TITLE
allow feed accounts to post without confirmed emails

### DIFF
--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -1275,7 +1275,7 @@ sub postevent {
         unless $u->equals($uowner) || $u->{'status'} eq 'A' || $flags->{'nomod'};
 
     return fail( $err, 155, "You must confirm your email address before posting." )
-        if $u->{'status'} eq 'N' && !$LJ::_T_CONFIG;
+        if $u->{'status'} eq 'N' && !$u->is_syndicated && !$LJ::_T_CONFIG;
 
     # post content too large
     # NOTE: requires $req->{event} be binary data, but we've already


### PR DESCRIPTION
Fixes #3254.

CODE TOUR: As we anticipated, the change to require a confirmed email when posting had unforeseen consequences. This fix will allow feed accounts to update again.