### PR TITLE
fix list display issue in tropo nav menu

### DIFF
--- a/ext/dw-nonfree/htdocs/stc/tropo/tropo-base.css
+++ b/ext/dw-nonfree/htdocs/stc/tropo/tropo-base.css
@@ -186,7 +186,7 @@ nav[role="navigation"] ul li.hover ul {
     white-space: nowrap;
     padding-right: 0.5rem;
 }
-nav ul li ul li {
+nav[role="navigation"] ul li ul li {
     float: none;
     width: 100%;
 }


### PR DESCRIPTION
It looks like one of the nav styling rules didn't have [role="navigation"] attached as part of #3140. Adding it appears to fix the issue in my testing.

CODE TOUR: fixes a user-reported display issue with the tropo hover menu.

![212679](https://github.com/dreamwidth/dreamwidth/assets/1976742/84100a02-bb2b-4ea1-9a19-ca2161e69c52)
