### PR TITLE
arguments to notify_administrator_add are backwards

### DIFF
--- a/cgi-bin/DW/Controller/Manage/Invites.pm
+++ b/cgi-bin/DW/Controller/Manage/Invites.pm
@@ -67,7 +67,7 @@ sub invites_handler {
             if ( $response eq 'yes' ) {
                 if ( $u->accept_comm_invite($cu) ) {
                     push @accepted, [ $cu, [ grep { $args->{$_} } @allattribs ] ];
-                    $cu->notify_administrator_add( $us->{$maintid}, $u ) if $args->{admin};
+                    $cu->notify_administrator_add( $u, $us->{$maintid} ) if $args->{admin};
                 }
             }
             elsif ( $response eq 'no' ) {


### PR DESCRIPTION
CODE TOUR: notify the recipient of the invite, not the sender.

Hard to test notifications effectively when all the test accounts are owned by one person. 😓 

Reported here: https://www.dreamwidth.org/support/see_request?id=47774