### PR TITLE
select user's personal journal by default on home page quick update

### DIFF
--- a/views/widget/quickupdate.tt
+++ b/views/widget/quickupdate.tt
@@ -73,7 +73,7 @@
                             items = security
                             selected = minsec
                     ) -%]</li>
-                    <li>&nbsp; to &nbsp;</li>
+                    <li style="margin-top: 0.4em;">&nbsp; to &nbsp;</li>
 
                     [%~ IF journallist.size > 1 %]
                         <li>[%- form.select(
@@ -82,6 +82,7 @@
                                 label = dw.ml( '/entry/form.tt.select.usejournal' )
 
                                 items = journallist
+                                selected = remote.user
                             )-%]</li>
                     [%~ ELSE ~%]
                         <li>


### PR DESCRIPTION
CODE TOUR: the default selection in the quick update widget on the logged in home page should be the user's personal journal, not the journal that comes alphabetically first in the list.

Also adds a small top margin to the "to" text string, to give it better vertical alignment with the form elements in the same row.

Fixes #3258.