### PR TITLE
importer should not require a confirmed email address to post

### DIFF
--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -1275,7 +1275,7 @@ sub postevent {
         unless $u->equals($uowner) || $u->{'status'} eq 'A' || $flags->{'nomod'};
 
     return fail( $err, 155, "You must confirm your email address before posting." )
-        if $u->{'status'} eq 'N' && !$u->is_syndicated && !$LJ::_T_CONFIG;
+        if $u->{'status'} eq 'N' && !$importer_bypass && !$u->is_syndicated && !$LJ::_T_CONFIG;
 
     # post content too large
     # NOTE: requires $req->{event} be binary data, but we've already


### PR DESCRIPTION
CODE TOUR: Recent change to require a confirmed email address before posting broke community imports.

Fixes #3262