### PR TITLE
Remove page unload handlers for drafts

### DIFF
--- a/htdocs/js/pages/entry/drafts.js
+++ b/htdocs/js/pages/entry/drafts.js
@@ -11,7 +11,6 @@ LJDraft.saveInProg = false;
 LJDraft.maxTimeout = 15000; // Maximum length of time to go between saves, even if user is still typing
 LJDraft.inputDelay = 3000; // Input debounce delay, so we're not saving on each individual keypress
 LJDraft.savedMsg = "Autosaved at [[time]]";
-LJDraft.savedUnload = false; // Flag so we don't double-post when trying various methods of page unload saves.
 
 LJDraft.handleInput = function (evt) {
     const date = Date.now();
@@ -92,12 +91,6 @@ LJDraft.saveBody = function () {
 
 };
 
-function unloadSave() {
-    LJDraft.savedUnload = true;
-    LJDraft.saveBody();
-    LJDraft.saveProperties();
-}
-
 function initDraft(askToRestore) {
     if (askToRestore && restoredDraft) {
         if (confirm(confirmMsg)) {
@@ -130,18 +123,6 @@ function initDraft(askToRestore) {
     $("#content").on('change', 'input.draft-autosave, textarea.draft-autosave', null, LJDraft.handleChange);
     $("#content").on('input', '#entry-body', null, LJDraft.handleInput);
 
-    // Try to save draft when page is closed/hidden
-    document.onvisibilitychange = function(){
-      if (document.visibilityState === "hidden" && !LJDraft.savedUnload) {
-        unloadSave();
-      }
-    };
-
-    window.onpagehide = function (event) {
-      if (!LJDraft.savedUnload) {
-        unloadSave();
-      }
-    };
 }
 
 


### PR DESCRIPTION
CODE TOUR: The drafts autosave on the new entry page had a function to try and do a last-ditch save when the page was unloaded (ie, closed), but it turns out this is very hard to detect and also caused a confusing race issue where it would save a post as a draft *after* it had been posted (and thus cleared from drafts)

<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
