### PR TITLE
fix coment -> comment typos

### DIFF
--- a/bin/worker/sphinx-search-gm
+++ b/bin/worker/sphinx-search-gm
@@ -235,7 +235,7 @@ sub _build_output {
 
                 } else {
                     # something happened, couldn't get the comment
-                    $match->{entry} = '(sorry, this coment has been deleted or is otherwise unavailable)';
+                    $match->{entry} = '(sorry, this comment has been deleted or is otherwise unavailable)';
                     $match->{subject} = 'Comment deleted or unavailable.';
                 }
                 push @out, $match;

--- a/styles/headsup/layout.s2
+++ b/styles/headsup/layout.s2
@@ -491,7 +491,7 @@ ul.entry-interaction-links, .comment-interaction-links {
     margin-top: .5em;
     }
 
-#primary .coment-management-links a, #primary .comment-interaction-links a, #primary .entry-management-links a, #primary .entry-interaction-links a {
+#primary .comment-management-links a, #primary .comment-interaction-links a, #primary .entry-management-links a, #primary .entry-interaction-links a {
     color: $*color_entry_interaction_links;
     }
 


### PR DESCRIPTION
CODE TOUR: fix a text typo and a CSS typo

https://www.dreamwidth.org/support/see_request?id=47818

A user pointed out that a text string on the search page had misspelled comment as "coment". I did a source grep for the typo and found that the text with the misspelling was hardcoded and couldn't be fixed via the translation system.

So this fixes that, but for extra credit it also fixes another text match for "coment" that showed up in the CSS rules included in the headsup layout file.