### PR TITLE
Fixes for modals in Foundation

### DIFF
--- a/htdocs/js/skins/jquery.focus-on-reveal.js
+++ b/htdocs/js/skins/jquery.focus-on-reveal.js
@@ -1,13 +1,13 @@
 jQuery(document).ready(function($) {
 
     // save previously focused item when we open
-    $(document).on('open', '[data-reveal]', function () {
+    $(document).on('open.fndtn.reveal', '[data-reveal]', function () {
       var $modal = $(this);
       $modal.data( "previously_focused", $( ":focus" ) );
     });
 
     // focus on the first input, for keyboard users
-    $(document).on('opened', '[data-reveal]', function () {
+    $(document).on('opened.fndtn.reveal', '[data-reveal]', function () {
       var $modal = $(this);
 
       $modal.data( "previously_focused", $( ":focus" ) );
@@ -15,7 +15,7 @@ jQuery(document).ready(function($) {
     });
 
     // switch back focus
-    $(document).on('closed', '[data-reveal]', function () {
+    $(document).on('closed.fndtn.reveal', '[data-reveal]', function () {
         var $modal = $(this);
 
         var focused = $modal.data( "previously_focused" );

--- a/htdocs/scss/foundation/components/_reveal.scss
+++ b/htdocs/scss/foundation/components/_reveal.scss
@@ -163,7 +163,8 @@ $z-index-base: 1005;
   line-height: 1;
   position: absolute;
   top: $reveal-close-top;
-  #{$opposite-direction}: $reveal-close-side;
+  border: 0;
+  #{$opposite-direction}: $reveal-close-top;
 }
 
 @include exports("reveal") {

--- a/htdocs/scss/skins/_nav.scss
+++ b/htdocs/scss/skins/_nav.scss
@@ -85,7 +85,7 @@ $nav-small-screen-header-height: 3em;
 
             .logout.button { display: block; margin-top: .5em; }
             ul { list-style: none; margin-left: 0; }
-            a.close-reveal-modal {
+            button.close-reveal-modal {
                 @include reveal-close();
             }
         }

--- a/schemes/common.tt
+++ b/schemes/common.tt
@@ -34,6 +34,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         dw.need_res( { group => "foundation" },
                     "js/foundation/foundation/foundation.reveal.js"
                     "js/skins/jquery.focus-on-reveal.js"
+                    "stc/css/components/foundation-icons.css"
         );
 
         dw.need_res( "stc/canary.css" );
@@ -122,7 +123,10 @@ the table based way can be removed when the entire site is Foundation-based.
 </ul>
 </div></div>
 
-<a class="close-reveal-modal">&#215;</a>
+<button type="button" class="fi-icon--with-fallback close-reveal-modal">
+    <span class="fi-icon fi-x" aria-hidden="true"></span>
+    <span class="fi-icon--fallback">Close</span>
+</button>
 </div><!-- end #account-links-text -->
 </div>
 </div><!-- end #account-links.row -->
@@ -157,7 +161,11 @@ the table based way can be removed when the entire site is Foundation-based.
         </div>
       </form>
       </div></div>
-      <a class="close-reveal-modal">&#215;</a>
+    <button type="button" class="fi-icon--with-fallback close-reveal-modal">
+        <span class="fi-icon fi-x" aria-hidden="true"></span>
+        <span class="fi-icon--fallback">Close</span>
+    </button>
+
     </div>
     </div>
     </div>

--- a/views/components/modal.tt
+++ b/views/components/modal.tt
@@ -15,9 +15,13 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [%- dw.need_res({ group => "foundation"}
     "js/foundation/foundation/foundation.reveal.js"
     "js/skins/jquery.focus-on-reveal.js"
+    "stc/css/components/foundation-icons.css"
 ) -%]
 
 <div id="[%- id -%]" class="reveal-modal [%- class.join(" ") -%]" [% IF options %]data-options="[%- options.dquote -%]" [% END %]data-reveal>
 [%- content -%]
-<a href="#0" class="close-reveal-modal" title="Close">&#215;</a>
+<button type="button" class="fi-icon--with-fallback close-reveal-modal">
+    <span class="fi-icon fi-x" aria-hidden="true"></span>
+    <span class="fi-icon--fallback">Close</span>
+</button>
 </div>


### PR DESCRIPTION
* fix event names in focus-on-reveal JS
* change close link to a button with fallback text

CODE TOUR: We discovered some issues with the login modal in Foundation pages that made them difficult to use via keyboard navigation. These have now been fixed!

Sample of modal with new icon button in Celerity
![image](https://github.com/dreamwidth/dreamwidth/assets/2245253/7d9e787a-4e92-4db7-a9b5-d82ba6139fba)

Fixes #2798 