### PR TITLE
Don't allow public access list creation via API

### DIFF
--- a/api/dist/components/schemas/accesslist.yaml
+++ b/api/dist/components/schemas/accesslist.yaml
@@ -11,6 +11,3 @@ properties:
     type: integer
     minimum: 0
     maximum: 255
-  is_public:
-    description: The visibility of the new accesslist. Default is false (private).
-    type: boolean

--- a/api/dist/journals/accesslists_all.yaml
+++ b/api/dist/journals/accesslists_all.yaml
@@ -53,9 +53,6 @@ paths:
                   type: integer
                   minimum: 0
                   maximum: 255
-                is_public:
-                  description: The visibility of the new accesslist. Default is false (private).
-                  type: boolean
       responses:
         "200":
           description: The id of the newly created accesslist.

--- a/api/src/components/schemas/accesslist.yaml
+++ b/api/src/components/schemas/accesslist.yaml
@@ -11,6 +11,3 @@ properties:
     type: integer
     minimum: 0
     maximum: 255
-  is_public:
-    description: The visibility of the new accesslist. Default is false (private).
-    type: boolean

--- a/cgi-bin/DW/Controller/API/REST/Journals.pm
+++ b/cgi-bin/DW/Controller/API/REST/Journals.pm
@@ -62,13 +62,11 @@ sub accesslists_new {
     return $self->rest_error("403") unless $user == $remote;
 
     my $body = $args->{body};
-    $body->{is_public} ||= 0;    #default false
     $body->{sortorder} ||= 0;
 
     my $group = $user->create_trust_group(
         groupname => $body->{name},
-        sortorder => $body->{sortorder},
-        is_public => $body->{is_public}
+        sortorder => $body->{sortorder}
     );
 
     return $self->rest_ok( { id => $group } );


### PR DESCRIPTION
CODE TOUR: Access lists and reading lists use the same backend representation, so it's possible to mark an access list as 'public' in code (because you can make reading lists public), but it's a bad idea and we don't let you do it through the site, so the API shouldn't let you do it either.

<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
