### PR TITLE
Fix discrepency between what the wizard says fields do and what they actually do

### DIFF
--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -5629,8 +5629,10 @@ function Entry::print_interaction_links(string target)
         if ($count > 0) {
             "</ul>";
         }
-    } elseif ($p.view == "read" or $p.view == "day" or $p.view == "recent" or $p.view == "network") {
+    } elseif ($p.view == "read" or $p.view == "network") {
         $this.comments->print($this, { "linktext" => $*text_post_comment_friends, "target" => $this.dom_id + "-reply" });
+    } elseif ($p.view == "day" or $p.view == "recent") {
+        $this.comments->print($this, { "linktext" => $*text_post_comment, "target" => $this.dom_id + "-reply" });
     } else {
         $this.comments->print();
     }


### PR DESCRIPTION
CODE TOUR: In the theme customization settings, there are two text fields you can customize: 'Text to leave a comment' and 'Text to leave a comment from your Reading page'. Contrary to what one would expect, the later text field is used for the link to leave comments EVERYWHERE that isn't a single entry view. This has been fixed, and the 'Text to leave a comment from your Reading page' is used on the Reading page, and, for paid accounts, the Network page (which is basically an extended Reading page), and the other reply text is used everywhere else.

<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
