### PR TITLE
Beta Entry Page bug fixes

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -890,7 +890,8 @@ sub _form_to_backend {
         }
     }
 
-    $req->{sticky_entry} = $post->{sticky_entry};
+    $req->{sticky_entry}  = $post->{sticky_entry};
+    $req->{sticky_select} = $post->{sticky_select};
 
     return 1;
 }

--- a/htdocs/js/pages/entry/drafts.js
+++ b/htdocs/js/pages/entry/drafts.js
@@ -120,7 +120,7 @@ function initDraft(askToRestore) {
    }
 
     // set up event handlers
-    $("#content").on('change', 'input.draft-autosave, textarea.draft-autosave', null, LJDraft.handleChange);
+    $("#content").on('change', '.draft-autosave', null, LJDraft.handleChange);
     $("#content").on('input', '#entry-body', null, LJDraft.handleInput);
 
 }


### PR DESCRIPTION
* Changing icons now triggers autosave correctly
* Possible to unsticky stickied entries via edit

CODE TOUR: Fixes for the new entry page! It is now possible to unsticky stickied entries by editing them, and changing icons now correctly triggers the draft autosave.

Fixes #3310 
Fixes #3309 