### PR TITLE
Fix some minor display issues with updated /manage/circle/edit page

### DIFF
--- a/htdocs/scss/components/foundation-icons.scss
+++ b/htdocs/scss/components/foundation-icons.scss
@@ -100,7 +100,7 @@ $include-html-fi-icon-classes: true !default;
         // .fi-burst:before { content: "\f123"; }
         .fi-calendar:before { content: "\f124"; }
         // .fi-camera:before { content: "\f125"; }
-        // .fi-check:before { content: "\f126"; }
+        .fi-check:before { content: "\f126"; }
         // .fi-checkbox:before { content: "\f127"; }
         // .fi-clipboard-notes:before { content: "\f128"; }
         // .fi-clipboard-pencil:before { content: "\f129"; }

--- a/htdocs/scss/pages/manage/circle-edit.scss
+++ b/htdocs/scss/pages/manage/circle-edit.scss
@@ -64,6 +64,10 @@ table .color-cell label {
     display:none;
 }
 
+table .check-cell {
+    white-space: nowrap;
+}
+
 table .swatch.hidden {
     display: none;
 }

--- a/views/manage/circle/edit/list.tt
+++ b/views/manage/circle/edit/list.tt
@@ -42,7 +42,7 @@
         </td>
 
         [%# subscription status %]
-        <td role="cell">
+        <td role="cell" class="check-cell">
             [% IF watch_list.$uid || u.can_watch(other_u) %]
                 [% form.checkbox(
                         name => "editfriend_edit_${uid}_watch",
@@ -76,7 +76,7 @@
 
         [%# ...and access/membership %]
         [% IF type=="people" %]
-        <td role="cell">
+        <td role="cell" class="check-cell">
             [% IF trust_list.$uid || u.can_trust(other_u) %]
                 [% form.checkbox(
                         name => "editfriend_edit_${uid}_trust",


### PR DESCRIPTION
CODE TOUR: We were missing one of the display icons for the /manage/circle/edit page, and I tweaked some CSS for nicer tablet/split desktop views.
<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
