### PR TITLE
trap ERR to see apache errors before the container dies

### DIFF
--- a/etc/docker/web/scripts/startup-prod.sh
+++ b/etc/docker/web/scripts/startup-prod.sh
@@ -9,7 +9,9 @@ perl -I$LJHOME/extlib/ $LJHOME/bin/checkconfig.pl || sleep infinity
 # Kick off Apache
 mkdir $LJHOME/ext/local/etc/apache2/sites-enabled || true
 cp $LJHOME/ext/local/dreamwidth-prod.conf $LJHOME/ext/local/etc/apache2/sites-enabled/dreamwidth.conf
+trap "cat /var/log/apache2/error_log 1>&2" ERR
 /usr/sbin/apache2ctl start
+trap - ERR
 
 # Kick off Varnish
 service varnish start


### PR DESCRIPTION
Normally startup-prod.sh exits when any simple command exits with error, killing the container. If there is an ERR trap registered, bash will still do the exit thing but will run the trap first. This seems like a reasonable way to get a look at the apache error log between the point when apache2ctl start fails and the container vanishes entirely.

CODE TOUR: More troubleshooting info when a web container fails to start