### PR TITLE
blacklist version 2.207 of IO::Compress and related modules

### DIFF
--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -9,7 +9,7 @@ Captcha::reCAPTCHA@0.99
 Class::Autouse
 Class::Data::Inheritable
 Class::Trigger
-Compress::Zlib
+Compress::Zlib~"!= 2.207"
 Convert::Base32
 CryptX
 Danga::Socket


### PR DESCRIPTION
CODE TOUR: avoid using a buggy version of a required perl module