### PR TITLE
fix cat loading error in $u->should_receive_support_notifications

### DIFF
--- a/cgi-bin/LJ/User/Permissions.pm
+++ b/cgi-bin/LJ/User/Permissions.pm
@@ -1294,8 +1294,9 @@ sub should_receive_support_notifications {
     return 0 unless $u->is_visible;
     return 0 unless $u->is_validated;
     return 0 unless $spcatid;
-    return 0 unless LJ::Support::can_read_cat( $spcatid, $u );
-    return 1;
+
+    my $cat = LJ::Support::load_cats($spcatid)->{$spcatid};
+    return LJ::Support::can_read_cat( $cat, $u );
 }
 
 sub support_points_count {


### PR DESCRIPTION
In my fix for #2315 I inadvertently introduced a bug, which wasn't caught until @rahaeli reported spotting the following TheSchwartz error:

`Can't use string ("12") as a HASH ref while "strict refs" in use at /home/dw/production/cgi-bin/LJ/Support.pm line 263.`

This patch should fix the problem, BUT I haven't been able to test it.

CODE TOUR: fix delivery of support notification emails