### PR TITLE
Add the authas input that the themechooser widget needs

### DIFF
--- a/htdocs/customize/index.bml
+++ b/htdocs/customize/index.bml
@@ -71,6 +71,11 @@ body<=
     $ret .= LJ::make_authas_select($remote, { authas => $GET{authas} });
     $ret .= "</form>";
 
+    if ($GET{authas}) {
+        $ret .= LJ::html_hidden(
+                { name => "authas", value => $GET{authas}, id => "_widget_authas" } );
+    }
+
     # if they're working as a community, reproduce the community management linkbar:
     if ( $u && $u->is_community ) {
         my $linkbar;


### PR DESCRIPTION
CODE TOUR: We have a bunch of things we call 'widgets' which are theoretically supposed to make code easier to reuse but in practice end up being black boxes of code where magic happens. Attempting to modernize some of the widgets broke the magic (very specifically named hidden input) one of the *other* widgets was using to say which account a theme should be applied to, which resulted in users being unable to change themes for the communities they managed. This adds the input back.

Fixes #3362 