### PR TITLE
Fix escaping for edittags page

### DIFF
--- a/views/edittags.tt
+++ b/views/edittags.tt
@@ -61,7 +61,7 @@
         [% IF usertags.size > 0 %]
             <select name='tags' multiple='multiple' class='multiple-select tagbox_nohist' onChange='edit_tagselect(this)'>
             [% FOREACH tag IN usertags %]
-                <option value='[% tag.name | html %]'>[% tag.name | html %]</option>
+                <option value="[% tag.name | html %]">[% tag.name | html %]</option>
             [% END %]
             </select>
         [% END %]


### PR DESCRIPTION
CODE TOUR: TIL the HTML cleaner function in Template Toolkit expects HTML attributes to be double-quoted, and thus does not escape single quotes, leading to chaos if your attribute is single-quoted.