### PR TITLE
Make our hidden inputs have a value on /manage/circle/edit

### DIFF
--- a/views/manage/circle/edit/list.tt
+++ b/views/manage/circle/edit/list.tt
@@ -26,7 +26,7 @@
         <tr role="row">
         [%# name %]
         <td scope='col' abbr='[% other_u.display_username %]' role="cell" class="name-cell">
-            [% form.hidden( name => "editfriend_edit_${uid}_user", selected => 1 ) %]
+            [% form.hidden( name => "editfriend_edit_${uid}_user", value => 1 ) %]
             [% other_u.ljuser_display %]
             <br /><span style='font-size: smaller;'>[% other_u.last_updated %]</span>
         </td>


### PR DESCRIPTION
CODE TOUR: This bit of code uses a bunch of hidden form fields to keep track of what users already exist on the list, but when we converted it to TT, these form fields were given names but no values, and an earlier step in the request processing workflow removes inputs without values, which means the code for the page didn't know where to check for changes. This has been rectified.