### PR TITLE
Make the linklist button use unicode instead of an HTML entity

### DIFF
--- a/views/widget/linkslist.tt
+++ b/views/widget/linkslist.tt
@@ -83,7 +83,7 @@
                 [% IF ct >= showlinks && caplinks > link_min %]
                     [% form.submit(
                         name => 'Widget[LinksList]_action:morelinks', 
-                        value => dw.ml('widget.linkslist.table.more') _ " &rarr;",
+                        value => dw.ml('widget.linkslist.table.more') _ " →",
                     'disabled' => (ct >= caplinks),
                     raw => 1
                     ) %]


### PR DESCRIPTION
CODE TOUR: Moving the linkslist widget from Perl to TT meant that a character encoded as an HTML entity was not getting processed as HTML and was instead just dumping the raw HTML into the button text. As it is 2024 and we have utf8, it is now the actual utf8 symbol that was the HTML entity for, which is much tidier.