### PR TITLE
back out commits for removing pnote/pnotes

### DIFF
--- a/cgi-bin/DW/Controller/Journal/AdultContent.pm
+++ b/cgi-bin/DW/Controller/Journal/AdultContent.pm
@@ -55,7 +55,7 @@ sub _extract_from_request {
     my $post = $r->post_args;
 
     return ( $r->note('returl') || $post->{ret} || $get->{ret},
-        $r->note('entry'), $r->note('user'), );
+        $r->pnote('entry'), $r->pnote('user'), );
 }
 
 sub adult_concepts_handler {

--- a/cgi-bin/DW/OAuth.pm
+++ b/cgi-bin/DW/OAuth.pm
@@ -295,9 +295,9 @@ sub user_for_protected_resource {
 
 sub current_token {
     my $r = DW::Request->get;
-    $r->note( 'oauth_token', $_[1] )
+    $r->pnote( 'oauth_token', $_[1] )
         if exists $_[1];
-    return $r->note('oauth_token');
+    return $r->pnote('oauth_token');
 }
 
 sub verify_nonce {

--- a/cgi-bin/DW/Request.pm
+++ b/cgi-bin/DW/Request.pm
@@ -170,6 +170,11 @@ Returns the method.
 Set or get a note.
 This must be a plain string.
 
+=head2 C<< $r->pnote( $note[, $value] ) >>
+
+Set or get a Perl note.
+This can be any perl ref or string.
+
 =head2 C<< $r->post_args >>
 
 Return the POST arguments.
@@ -246,7 +251,7 @@ Turn off caching for this resource.
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (c) 2008-2024 by Dreamwidth Studios, LLC.
+Copyright (c) 2008-2013 by Dreamwidth Studios, LLC.
 
 This program is free software; you may redistribute it and/or modify it under
 the same terms as Perl itself. For a copy of the license, please reference

--- a/cgi-bin/DW/Request/Apache2.pm
+++ b/cgi-bin/DW/Request/Apache2.pm
@@ -104,6 +104,17 @@ sub note {
     }
 }
 
+# searches for a given pnote and returns the value, or sets it
+sub pnote {
+    my DW::Request::Apache2 $self = $_[0];
+    if ( scalar(@_) == 2 ) {
+        return $self->{r}->pnotes->{ $_[1] };
+    }
+    else {
+        return $self->{r}->pnotes->{ $_[1] } = $_[2];
+    }
+}
+
 # searches for a given header and returns the value, or sets it
 sub header_in {
     my DW::Request::Apache2 $self = $_[0];

--- a/cgi-bin/DW/Request/Standard.pm
+++ b/cgi-bin/DW/Request/Standard.pm
@@ -27,9 +27,10 @@ use HTTP::Response;
 use HTTP::Status qw//;
 
 use fields (
-    'req',      # The HTTP::Request object
-    'res',      # a HTTP::Response object
-    'notes',    # storage for request-lifetime data
+    'req',    # The HTTP::Request object
+    'res',    # a HTTP::Response object
+    'notes',
+    'pnotes',
 
     # we have to parse these out ourselves
     'uri',
@@ -50,6 +51,7 @@ sub new {
     $self->{res}         = HTTP::Response->new(200);
     $self->{uri}         = $self->{req}->uri;
     $self->{notes}       = {};
+    $self->{pnotes}      = {};
     $self->{read_offset} = 0;
 
     # now stick ourselves as the primary request ...
@@ -122,6 +124,17 @@ sub note {
     }
     else {
         return $self->{notes}->{ $_[1] } = $_[2];
+    }
+}
+
+# searches for a given pnote and returns the value, or sets it
+sub pnote {
+    my DW::Request::Standard $self = $_[0];
+    if ( scalar(@_) == 2 ) {
+        return $self->{pnotes}->{ $_[1] };
+    }
+    else {
+        return $self->{pnotes}->{ $_[1] } = $_[2];
     }
 }
 

--- a/cgi-bin/DW/Routing.pm
+++ b/cgi-bin/DW/Routing.pm
@@ -206,7 +206,7 @@ sub call_hash {
     my $hash = $opts->call_opts;
     return undef unless $hash && $hash->{sub};
 
-    $r->note( routing_opts => $opts );
+    $r->pnote( routing_opts => $opts );
     return $r->call_response_handler( \&_call_hash );
 }
 
@@ -214,7 +214,7 @@ sub call_hash {
 # Perl Response Handler for call_hash
 sub _call_hash {
     my $r    = DW::Request->get;
-    my $opts = $r->note('routing_opts');
+    my $opts = $r->pnote('routing_opts');
 
     $opts->prepare_for_call;
 

--- a/cgi-bin/bml/scheme/tt_runner.look
+++ b/cgi-bin/bml/scheme/tt_runner.look
@@ -5,7 +5,7 @@ use DW::Template;
 use DW::Request;
 
 my $r = DW::Request->get;
-my $scheme = $r->note('actual_scheme');
+my $scheme = $r->pnote('actual_scheme');
 die "Somehow we went down the TT path for a BML scheme" unless $scheme && $scheme->engine eq 'tt';
 
 return BML::ebml( DW::Template->render_scheme( $scheme, $_[2]->{BODY}, {

--- a/t/atom-post.t
+++ b/t/atom-post.t
@@ -75,7 +75,7 @@ sub do_request {
             }
         },
         setup_dw_request => sub {
-            $_[0]->note( $_ => $data->{$_} ) foreach %$data;
+            $_[0]->pnote( $_ => $data->{$_} ) foreach %$data;
         },
         routing_data => \%routing_data,
     );


### PR DESCRIPTION
Removes the changes from the following commits:
- 36730c9
- 72a0f4a
- f757a43

CODE TOUR: trying to remove dependencies on Apache, but this method was more deeply embedded than we realized, apparently?