### PR TITLE
Show session messages on S2 pages, too.

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2432,7 +2432,9 @@ sub Page {
         _styleopts            => LJ::viewing_style_opts(%$get),
         timeformat24          => $remote && $remote->use_24hour_time,
         include_meta_viewport => $r->cookie('no_mobile') ? 0 : 1,
+        session_msgs          => $r->msgs
     };
+    $r->clear_msgs;
 
     if ( $opts && $opts->{'saycharset'} ) {
         $p->{'head_content'} .=

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -280,6 +280,13 @@ class UserLink
     var readonly UserLink[] children "Not Implemented: An array of child UserLink objects.";
 }
 
+class SessionMsg
+"A site session message to show the user."
+{
+    var readonly string level "The message importance level";
+    var readonly string item "The text content of the message";
+}
+
 class UserLite
 "A 'lite' version of a [class[User]] which the system often has more readily-available than a full version."
 {
@@ -624,6 +631,8 @@ class Page
 
     var Link{} data_link "Links to various machine-readable data sources relating to this page";
     var string[] data_links_order "An array of data views which can be used to order the data_link hash";
+
+    var SessionMsg[] session_msgs "An array of session messages to display at the top of the page";
 
     var readonly string customtext_title "Header of customtext module";
     var readonly string customtext_url "URL for header of customtext module";
@@ -4936,6 +4945,18 @@ function Page::print()
     """
                     <div id="primary"><div class="inner">
                         """;
+                        foreach var SessionMsg msg ($.session_msgs) {
+                            """
+                            <div class="radius session-msg-box $msg.level">
+                                <span class="invisible"><b>$msg.level:</b> </span>
+                            """;
+                            print safe """
+                                $msg.item
+                            """;
+                            """
+                            </div>
+                            """;
+                        }
                         $this->print_body();
     """
                     </div></div><!-- end primary and primary>inner -->


### PR DESCRIPTION
CODE TOUR: We've had session message flashing (basically little temporary messages like 'Edit successful!' that show after taking an action, and which vanish when you navigate to a new page) for a while now, but when we upgraded the tag editing page, they got added there, too, and we discovered a bug: they didn't show in journal-styled pages, causing them to appear on the next site-styled page you visited instead, which was generally very confusing. This adds those messages to journal-styled pages, currently with very minimal styling.

This will require reloading all the core2 layers in the DB. I'm sorry in advance. I apparently [put styling in](https://github.com/dreamwidth/dreamwidth/blob/eff51877ee43aa1fb983d99ee46849220193831a/htdocs/stc/lj_base.css#L188) when I first implemented this, so messages have a 1px border with the color inherited from whatever the current text color is in the scope. No alert level colors yet but at  the moment the tag update success is the only thing that'll print here.
