### PR TITLE
Update _dreamwidth.tt page footer link

### DIFF
--- a/ext/dw-nonfree/schemes/_dreamwidth.tt
+++ b/ext/dw-nonfree/schemes/_dreamwidth.tt
@@ -30,7 +30,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <li><a href="[% site.root %]/site/">[% 'sitescheme.footer.sitemap' | ml %]</a> &bull; </li>
     <li><a href="[% site.root %]/site/suggest">[% 'sitescheme.footer.suggestion' | ml %]</a> &bull; </li>
     <li><a href="[% site.root %]/site/opensource">[% 'tropo.footer.opensource' | ml %]</a> &bull; </li>
-    <li><a href="[% site.root %]/support">[% 'sitescheme.accountlinks.help' | ml %]</a></li>
+    <li><a href="[% site.root %]/support/">[% 'sitescheme.accountlinks.help' | ml %]</a></li>
 </ul>
 <p>[% 'sitescheme.footer.info' | ml %]</p>
 [% IF site.is_canary %]


### PR DESCRIPTION
CODE TOUR: Minor edit - added forward slash at the end of the /support/ URL in the page footer. Should fix #3271 

<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
