### PR TITLE
No longer using Freenode.

### DIFF
--- a/ext/dw-nonfree/views/misc/about.tt
+++ b/ext/dw-nonfree/views/misc/about.tt
@@ -60,4 +60,4 @@ To learn more about our business operations, check out our <a href="http://wiki.
 
 <h1>Learn More</h1>
 
-<p> For even more information, you can read our <a href="http://wiki.dreamwidth.net/notes/">Dreamwidth wiki</a>. We'd also love to hear from you in our irc channel: irc.freenode.net (port 6667), channel #dreamwidth. </p>
+<p> For even more information, you can read our <a href="http://wiki.dreamwidth.net/notes/">Dreamwidth wiki</a>. We'd also love to hear from you in our IRC channel: irc.libera.chat (port 6667), channel #dreamwidth. </p>


### PR DESCRIPTION
Reported by thesecretmaster in IRC.

CODE TOUR: https://www.dreamwidth.org/about wasn't updated when Dreamwidth IRC moved from Freenode to Libera Chat.
