### PR TITLE
Show dates on shop order history

### DIFF
--- a/cgi-bin/DW/Controller/Shop.pm
+++ b/cgi-bin/DW/Controller/Shop.pm
@@ -175,8 +175,10 @@ sub shop_history_handler {
     my $r      = DW::Request->get;
     my $remote = $rv->{remote};
 
-    my @carts    = DW::Shop::Cart->get_all( $remote, finished => 1 );
-    my @cartrows = map { $_->{date} => DateTime->from_epoch( epoch => $_->starttime ) } @carts;
+    my @carts = DW::Shop::Cart->get_all( $remote, finished => 1 );
+    foreach my $cart (@carts) {
+        $cart->{date} = DateTime->from_epoch( epoch => $cart->starttime );
+    }
 
     return DW::Template->render_template( 'shop/history.tt', { carts => \@carts } );
 }


### PR DESCRIPTION
CODE TOUR: The shop order history page wasn't showing order dates in its table, even though the dates existed when you looked at individual orders. This sorts out the confusing code causing this to happen.

Fixes #3394 