### PR TITLE
Fix profile page link to shop

### DIFF
--- a/cgi-bin/DW/Logic/UserLinkBar.pm
+++ b/cgi-bin/DW/Logic/UserLinkBar.pm
@@ -105,7 +105,7 @@ sub fix_link {
     $link->{image} = "$LJ::IMGPREFIX/silk/profile/$link->{image}"
         if $link->{image} && $link->{image} !~ /^$LJ::IMGPREFIX/;
     $link->{url} = "$LJ::SITEROOT/$link->{url}"
-        if $link->{url} && $link->{url} !~ /^$LJ::SITEROOT/;
+        if $link->{url} && $link->{url} !~ /^(?:$LJ::SITEROOT|$LJ::SHOPROOT)/;
 
     if ( my $ml = delete $link->{title_ml} ) {
         $link->{title} = LJ::Lang::ml($ml);
@@ -557,7 +557,9 @@ sub buyaccount {
         $type = 'comm' if $u->is_community;
 
         my $link = {
-            url      => $remote_is_u ? "shop/account?for=self" : "shop/account?for=gift&user=$user",
+            url => $remote_is_u
+            ? "$LJ::SHOPROOT/account?for=self"
+            : "$LJ::SHOPROOT/account?for=gift&user=$user",
             image    => 'buy_account.png',
             text_ml  => "userlinkbar.buyaccount.$type",
             title_ml => "userlinkbar.buyaccount.title.$type",


### PR DESCRIPTION
CODE TOUR: We had to move the shop to shop.dreamwidth.org for extremely unexciting compliance reasons, and most of the references to the old dreamwidth.org/shop got updated, but we missed the one on the profile page - it would get you to the shop after a redirect, but it dropped the info about the account you wanted to buy paid time for along the way which was declared 'suboptimal'. This fixes the issue.

<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
