### PR TITLE
Fix links in the currenttheme widget

### DIFF
--- a/views/widget/currenttheme.tt
+++ b/views/widget/currenttheme.tt
@@ -9,10 +9,10 @@
     <h3 class="smaller">[% theme.name %]</h3>
 
     [%- layout_link = "<a href='${site.root}/customize/$getextra${getsep}layoutid=${theme.layoutid}$showarg' class='theme-current-layout'><em>$layout_name</em></a>" -%]
-    [%- special_link_opts = "href='$LJ::SITEROOT/customize/$getextra${getsep}cat=special$showarg' class='theme-current-cat'" -%]
+    [%- special_link_opts = "href='${site.root}/customize/$getextra${getsep}cat=special$showarg' class='theme-current-cat'" -%]
     <p class='theme-current-desc'>
     [%- IF designer -%]
-        [%- designer_link = "<a href='$LJ::SITEROOT/customize/$getextra${getsep}designer=${dw.url(designer)$showarg' class='theme-current-designer'>$designer</a>" -%]
+        [%- designer_link = "<a href='${site.root}/customize/$getextra${getsep}designer=${dw.url(designer)}$showarg' class='theme-current-designer'>$designer</a>" -%]
         [% dw.ml( 'widget.currenttheme.designer', { 'designer' => designer_link } ) %]
         [% dw.ml( 'widget.currenttheme.desc2', { 'style' => layout_link } ) %]
     [%- ELSIF layout_name -%]


### PR DESCRIPTION
CODE TOUR: When we converted the 'Current Theme' widget, a few links didn't get converted quite properly, and have now been fixed.

Fixes #3401 - on consideration I opted not to go with rewriting to use `create_url` because it wasn't as straightforward as I thought.
<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
