### PR TITLE
Remove debug code causing errors

### DIFF
--- a/cgi-bin/LJ/Widget/LayoutChooser.pm
+++ b/cgi-bin/LJ/Widget/LayoutChooser.pm
@@ -76,7 +76,6 @@ sub handle_post {
     my $post  = shift;
     my %opts  = @_;
 
-    print "handle post";
     my $u = $class->get_effective_remote();
     die "Invalid user." unless LJ::isu($u);
 


### PR DESCRIPTION
CODE TOUR: It turns out debug print messages do not make valid JSON! Who knew, right? The layout chooser widget now returns valid JSON that does not cause it to spew errors when you select a new layout.