### PR TITLE
fix failing test t/post.t

### DIFF
--- a/t/post.t
+++ b/t/post.t
@@ -236,9 +236,10 @@ my $postdata = {
 };
 
 my $postdecoded_bare = {
-    event   => $postdata->{event},
-    subject => undef,
-    slug    => '',
+    event         => $postdata->{event},
+    subject       => undef,
+    sticky_select => undef,
+    slug          => '',
 
     security  => 'public',
     allowmask => 0,


### PR DESCRIPTION
The sticky_select form fix from #3311 changed the expected return value of the entry object and caused t/post.t to complain. This is a good thing, we want it to detect these changes! But let's tell it that this is OK so the test will pass.

CODE TOUR: Fixes an automated development test; no user impact.