### PR TITLE
some minor whitespace adjustments to converted shop pages

### DIFF
--- a/views/shop/gifts.tt
+++ b/views/shop/gifts.tt
@@ -8,18 +8,15 @@
          [% person.last_updated %]
 
         [%- UNLESS nopaid -%]
-             [<a href='[% person.gift_url  %]'>
-            [% dw.ml( '.buy.gift' ) %]</a>]
+             [<a href='[% person.gift_url %]'>[% dw.ml( '.buy.gift' ) %]</a>]
         [%- END -%]
 
         [%- IF person.is_personal -%]
-             [<a href='[% person.gift_points_url  %]'>
-            [% dw.ml( '.buy.points' ) %]</a>]
+             [<a href='[% person.gift_points_url %]'>[% dw.ml( '.buy.points' ) %]</a>]
         [%- END -%]
 
         [% IF person.is_personal && ! person.equals( remote ) -%]
-             [<a href='[% person.transfer_points_url  %]'>
-            [% dw.ml( '.buy.points.transfer' ) %]</a>]
+             [<a href='[% person.transfer_points_url %]'>[% dw.ml( '.buy.points.transfer' ) %]</a>]
         [%- END -%]
         </li>
     [% END %]

--- a/views/shop/randomgift.tt
+++ b/views/shop/randomgift.tt
@@ -21,8 +21,8 @@
     <form method='post'>
     [% form.hidden( name = 'username', value = randomu.user ) %]
     [% form.submit( value = dw.ml( '.form.submit', { username => randomu.user } ) ) %] 
-    <a href='[% site.shoproot %]/randomgift?type=[% type %]'>[% dw.ml( ".form.getanother.$type") %]</a>
-    &nbsp;&nbsp;<a href='[% site.shoproot %]/randomgift?type=[% othertype %]'>[% dw.ml( ".form.switchtype.$type") %]</a>
+    <p><a href='[% site.shoproot %]/randomgift?type=[% type %]'>[% dw.ml( ".form.getanother.$type") %]</a>
+    &nbsp;&nbsp;<a href='[% site.shoproot %]/randomgift?type=[% othertype %]'>[% dw.ml( ".form.switchtype.$type") %]</a></p>
     </form><br />
 [% ELSE %]
     <p>[% dw.ml( ".nousers.$type") %]</p>


### PR DESCRIPTION
CODE TOUR: This makes some minor cosmetic adjustments to the shop pages where whitespace got shifted around during the conversion away from BML.

1. Adds paragraph tags around the links after the submit button here:
<img width="930" alt="Screenshot 2024-11-30 at 5 23 33 PM" src="https://github.com/user-attachments/assets/2c182495-a0df-4167-9ec8-6829c1138fb4">

2. Removes the visible space in front of each link in the action list here:
<img width="351" alt="Screenshot 2024-11-30 at 5 22 52 PM" src="https://github.com/user-attachments/assets/5ea6d79c-1fec-4c15-9f46-d0cebae7309d">
