### PR TITLE
fix FAQ links in the shop

### DIFF
--- a/views/shop/account.tt
+++ b/views/shop/account.tt
@@ -35,10 +35,10 @@
 [% END %]
 
     [% IF for == 'self' %]
-        <div class='leftybox'>[% dw.ml( '.intro.self', { user => remote.ljuser_display, aopts => "href='$LJ::HELPURL{paidaccountinfo}'" } ) %]</div>
+        <div class='leftybox'>[% dw.ml( '.intro.self', { user => remote.ljuser_display, aopts => "href='${site.help.paidaccountinfo}'" } ) %]</div>
         [% paid_status %]
     [% ELSIF for.size > 0 %]
-        <p>[% dw.ml( ".intro.$for", { aopts => "href='$LJ::HELPURL{paidaccountinfo}'" } ) %]</p>
+        <p>[% dw.ml( ".intro.$for", { aopts => "href='${site.help.paidaccountinfo}'" } ) %]</p>
     [% END %]
 
     <div style='clear: both;'></div>

--- a/views/shop/gifts.tt
+++ b/views/shop/gifts.tt
@@ -38,7 +38,7 @@
     <h2>[% dw.ml( '.free.header' ) %]</h2>
     <p>
     [% dw.ml( '.free.about',
-            { aopts => "href='${site.root}/support/faqbrowse?faqid=153'" } ) %]
+            { aopts => "href='${site.help.paidaccountinfo}'" } ) %]
     </p>
 
     [%#build different lists for personal and community accounts %]


### PR DESCRIPTION
CODE TOUR: This updates broken/incorrect links in the shop to the FAQ that explains our paid account features.

There were 2 places where `$LJ::HELPURL{paidaccountinfo}` needed to be replaced with `${site.help.paidaccountinfo}`. I also noticed a hardcoded link to FAQ 153 labelled "paid features" and changed it to be the same as the others.

Fixes #3375.