### PR TITLE
Add Foundation to a bunch of TT pages missing it

### DIFF
--- a/views/birthdays.tt
+++ b/views/birthdays.tt
@@ -14,6 +14,7 @@ the same terms as Perl itself. For a copy of the license, please reference
 %]
 
 [%- sections.title = '.title' | ml -%]
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 
 [% IF otheruser %]
     <p>[% '.description.others' | ml(user = u.ljuser_display) %]</p>
@@ -30,18 +31,20 @@ the same terms as Perl itself. For a copy of the license, please reference
 <form method='GET' action='[% site.root %]/birthdays'>
     [%- form.textbox( label = dw.ml( '.findothers' )
         name = 'user'
+        class = 'inline'
         maxlength = 25
         size = 15
+        style = "display: inline-block"
     )
     -%]
 
-    <input type="submit" value="[% '.view' | ml %]" />
+    <input class="button" type="submit" value="[% '.view' | ml %]" />
 </form>
 
 [% FOREACH month = bdaymonths %]
-    <h1> [% month %] </h1>
+    <h2> [% month %] </h2>
     [% FOREACH bdayuser = bdays.$month %]
-        <ul>[% bdayuser.day %]:
-            [% bdayuser.ljname %] - [% bdayuser.name %]</ul>
+        <ul><li>[% bdayuser.day %]:
+            [% bdayuser.ljname %] - [% bdayuser.name %]</li></ul>
     [% END %]
 [% END %]

--- a/views/interests/add.tt
+++ b/views/interests/add.tt
@@ -18,6 +18,7 @@
 </style>
 [% END -%]
 
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 [%- sections.title='.title' | ml -%]
 
 [%- IF need_post -%]

--- a/views/interests/enmasse.tt
+++ b/views/interests/enmasse.tt
@@ -13,11 +13,18 @@
 
 [%- sections.head = BLOCK %]
 <style type='text/css'>
-    div.tagcloud a { text-decoration: none; }
-    ul.contentlist li { padding-bottom: 3px; }
+    #interests {
+    display: flex; 
+    flex-wrap: wrap; 
+    justify-content: 
+    space-evenly; 
+    gap: 0.5em
+    }
+    #interests div {width:15em;}
 </style>
 [% END -%]
 
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 [%- sections.title='.title' | ml -%]
 
 <form method='get' action='interests'>
@@ -26,33 +33,26 @@
 [% authas_html %]</form>
 <form method='post' action='interests[% getextra %]'>
 [%- dw.form_auth %]
-<h1>[% '.enmasse.header' | ml %]</h1>
+<h2>[% '.enmasse.header' | ml %]</h2>
 <p>[% enmasse_body | ml(user = fromu.ljuser_display,
                         target = u.ljuser_display) %]</p>
-<div style='margin-left: 40px; margin-top: 20px;'>
-<table summary='' cellpadding='0' cellspacing='0' border='0' width='100%'>
-[%- USE table(enmasse_data, cols=3) -%]
-[%- FOREACH rows = table.rows %]
-<tr valign='middle'>
-    [%- FOREACH cell = rows -%]
-        [%- IF cell.int -%]
-            <td align='left' nowrap='nowrap'>
-            <input type='checkbox' [% IF cell.is_checked %] checked='checked' [% END %]
-                name='[% cell.checkid %]' id='[% cell.checkid %]' value='1' />
-            <label for='[% cell.checkid %]'>
-            [%- IF cell.is_checked %] <strong> [% END -%]
-            [%- cell.int -%]
-            [%- IF cell.is_checked %] </strong> [% END -%]
-            </label></td>
-        [%- ELSE -%]
-            <td></td>
-        [%- END -%]
+<div id="interests">
+    [%- FOREACH int = enmasse_data -%]
+        <div>
+            <label>
+            <input type='checkbox' [% "checked='checked'" IF cell.is_checked %]
+                name='[% int.checkid %]' id='[% int.checkid %]' value='1' class="inline" />
+
+            [%- "<strong>" IF int.is_checked %]
+            [%- int.int -%]
+            [%- "</strong>" IF int.is_checked %]
+            </label>
+        </div>
     [%- END -%]
-</tr>
-[%- END -%]
-</table></div>
+</div>
 <input type='hidden' name='mode' value='enmasse_do' />
 <input type='hidden' name='fromuser' value='[% fromu.user %]' />
 <input type='hidden' name='allintids' value='[% allintids %]' />
-<h1>[% '.finished.header' | ml %]</h1><p>[% '.finished.about' | ml %]</p>
-<div class='action-box'><div class='inner'><input type='submit' value='[% ".finished.save_button" | ml %]' /></div></div><div class='clear-floats'></div></form>
+<h2>[% '.finished.header' | ml %]</h2>
+<p>[% '.finished.about' | ml %]</p>
+<input class="button" type='submit' value='[% ".finished.save_button" | ml %]' /></form>

--- a/views/interests/enmasse_do.tt
+++ b/views/interests/enmasse_do.tt
@@ -18,6 +18,7 @@
 </style>
 [% END -%]
 
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 [%- sections.title='.title' | ml -%]
 
 <h1>[% '.results.header' | ml %]</h1>

--- a/views/interests/findsim.tt
+++ b/views/interests/findsim.tt
@@ -17,6 +17,7 @@
     .anchorlinks { text-align: center; margin: 2em 0; }
 </style>
 [% END -%]
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 
 [%- sections.title='.title' | ml -%]
 

--- a/views/interests/index.tt
+++ b/views/interests/index.tt
@@ -18,39 +18,66 @@
 </style>
 [% END -%]
 
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 [%- sections.title='.title' | ml -%]
 
 <p>[% '.interests.text' | ml %]</p>
-<table summary='' cellspacing='5' style='margin-top: 10px; margin-left: 30px; margin-bottom: 10px;'>
+<div class="columns">
 
 [%- IF can_use_popular -%]
-<tr valign='top'><td colspan='2'>
-<a href="interests?view=popular">[% '.interests.viewpop' | ml %]</a>
-</td></tr>
+<div class="row">
+  <div class="columns small-12">
+    <a href="interests?view=popular">[% '.interests.viewpop' | ml %]</a>
+  </div>
+</div>
 [%- END -%]
 
-<tr valign='top'><td align='left'>[% 'interests.interested.in' | ml %]</td>
-<td><form method='get' action='interests'>
-<input type="text" name="int" size="20" />&nbsp;
-<input type='submit' value='[% "interests.interested.btn" | ml %]' />
-<br />[% '/directory/index.tt.int_multiple' | ml %]
-</form></td></tr>
+<div class="row">
+<form method='get' action='interests'>
+  <div class="columns medium-5">
+    <label for="int">[% 'interests.interested.in' | ml %]</label>
+  </div>
+  <div class="columns medium-5">
+    <input type="text" name="int" size="20" style="margin-bottom:0;"/>
+    <small>[% '/directory/index.tt.int_multiple' | ml %]</small>
+  </div>
+  <div class="columns medium-2">
+    <input type='submit' class="button" value='[% "interests.interested.btn" | ml %]' />
+    </div>
+</form>
+</div>
 
 [%- IF can_use_findsim -%]
-<tr valign='top'><td>[% '.interests.findsim' | ml %]</td><td>
+<div class="row">
 <form method='get' action='interests'>
-<input type='hidden' name='mode' value='findsim_do' />
-<input type="text" name="user" size="20" value="[% remote.user %]" />&nbsp;
-<input type='submit' value='[% "interests.interested.btn" | ml %]' />
-</form></td></tr>
+  <div class="columns medium-5">
+    <label for="user">[% '.interests.findsim' | ml %]</label>
+  </div>
+  <div class="columns medium-5">
+     <input type='hidden' name='mode' value='findsim_do' />
+    <input type="text" name="user" size="20" value="[% remote.user %]" />
+  </div>
+  <div class="columns medium-2">
+    <input type='submit' class="button" value='[% "interests.interested.btn" | ml %]' />
+    </div>
+</form>
+</div>
 [%- END -%]
 
-<tr valign='top'><td>[% 'interests.enmasse.intro' | ml %]</td><td>
+<div class="row">
 <form method='get' action='interests'>
-<input type='hidden' name='mode' value='enmasse' />
-<input type="text" name="fromuser" size="20" />&nbsp;
-<input type='submit' value='[% "interests.enmasse.btn" | ml %]' />
-</form></td></tr>
+  <div class="columns medium-5">
+    <label for="fromuser">[% 'interests.enmasse.intro' | ml %]</label>
+  </div>
+  <div class="columns medium-5">
+    <input type='hidden' name='mode' value='enmasse' />
+    <input type="text" name="fromuser" size="20" />
+  </div>
+  <div class="columns medium-2">
+    <input type='submit' class="button" value='[% "interests.enmasse.btn" | ml %]' />
+    </div>
+</form>
+</div>
 
-</table>
-[% '.nointerests.text2' | ml(aopts = "href='$site.root/manage/profile/'") %]
+</div>
+[% '.nointerests.text3' | ml(aopts = "href='$site.root/manage/profile/'") %]

--- a/views/interests/index.tt.text
+++ b/views/interests/index.tt.text
@@ -5,7 +5,7 @@
 
 .interests.viewpop=View popular interests
 
-.nointerests.text2=If you don't have any interests listed, you can add some by going to the <a [[aopts]]>Edit Personal Information</a> page.
+.nointerests.text3=If you don't have any interests listed, you can add some by going to the <a [[aopts]]>Edit Profile</a> page.
 
 .title=Interests
 

--- a/views/interests/popular.tt
+++ b/views/interests/popular.tt
@@ -18,9 +18,10 @@
 </style>
 [% END -%]
 
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 [%- sections.title='.title' | ml -%]
 
-<h1>[% '.popular.head' | ml %]</h1><p>[% '.popular.text' | ml %]
+<h2>[% '.popular.head' | ml %]</h2><p>[% '.popular.text' | ml %]
 [%- IF no_text_mode -%]
     [% '.popular.textmode'
      | ml(aopts = "href='$site.root/interests?view=popular&mode=text'") %]
@@ -28,7 +29,7 @@
 </p>
 [%- IF pop_ints -%]
     [%- IF no_text_mode; pop_cloud; ELSE -%]
-        <p><table class="table"><thead><tr>
+        <table class="table"><thead><tr>
             <th width='150' style="text-align: left">
             [% '.interest' | ml %]</th>
             <th>[% '.count' | ml %]</th>
@@ -39,6 +40,6 @@
             <td>[% i.value %]</td>
         </tr>
         [%- END -%]
-        </table></p>
+        </table>
     [%- END -%]
 [%- ELSE; '.error.nodata' | ml; END -%]

--- a/views/legal/index.tt
+++ b/views/legal/index.tt
@@ -16,12 +16,13 @@
 
 [%- sections.head = BLOCK %]
 <style type='text/css'>
-#content dl dt { font-size: bigger; font-weight: bold; }
+#content dl dt { font-size: larger; font-weight: bold; }
 #content dl dd { margin-left: 2em; margin-bottom: 1em; }
 </style>
 [% END -%]
 
 [%- sections.title='.title' | ml(sitename = site.name) -%]
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 
 <dl>
 [% FOREACH topic = index %]

--- a/views/legal/privacy.tt
+++ b/views/legal/privacy.tt
@@ -14,6 +14,7 @@
 %]
 
 [%- sections.title='Privacy Policy' -%]
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 
 <p>We hate legalese, so we've tried to make ours readable. If you've got any questions, feel free to <a href='[% site.root %]/support/submit'>ask us</a>, and we'll do our best to answer.</p>
 

--- a/views/legal/tos.tt
+++ b/views/legal/tos.tt
@@ -12,7 +12,7 @@
   # reference 'perldoc perlartistic' or 'perldoc perlgpl'.
   #
 %]
-
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 [%- sections.title='Terms of Service' -%]
 
 <p>We hate legalese, so we've tried to make ours readable. If you've got

--- a/views/manage/emailpost_help.tt
+++ b/views/manage/emailpost_help.tt
@@ -10,28 +10,18 @@ the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 
 %]
-
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 [%- sections.title = '.title' | ml -%]
 
 [%- sections.head = BLOCK %]
     <style type="text/css">
-        fieldset {
-            border: 1px solid #cdcdcd;
-            margin-bottom: 15px;
-        }
-        legend {
-            padding: 2px 10px 2px 10px;
-            border: 1px solid #cdcdcd;
-            font-size: 14px;
-            font-weight: bold;
-        }
         div.indent {
-            margin-left: 40px;
+            margin-left:3rem;
         }
         div.emailex {
-            font-family: courier;
-            border: solid black 1px;
-            padding: 5px;
+            font-family: monospace, courier;
+            border-style: dashed;
+            padding: 0.5rem;
         }
     </style>
 [%- END -%]
@@ -157,24 +147,22 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- topic = topics_by_name.$type;
     IF topic -%]
-<hr /><br />
+<hr />
 
 <h1>[% ".${topic.code}.header" | ml %]</h1>
-<br />
+
   [% FOREACH sect IN topic.sects %]
-<fieldset>
-  <legend>[% ".${topic.code}.${sect}.header" | ml %]</legend>
+<fieldset class="border">
+  <legend class="border">[% ".${topic.code}.${sect}.header" | ml %]</legend>
     [% IF paragraphs.${type}.exists(sect) %]
   <p>[% ".${topic.code}.${sect}.text" | ml(paragraphs.${type}.$sect) %]</p>
     [% END %]
     [% IF messages.${type}.exists(sect) %]
-  <div class='emailex'>[% messages.${type}.${sect}.join('<br>'); %]</div>
+  <div class='emailex border'>[% messages.${type}.${sect}.join('<br>'); %]</div>
     [% ELSIF sect == 'security'; security_body.join('<br>'); END %]
 </fieldset>
   [%- END -%]
 [%- END -%]
-
-<br />
 
 [%- order = topic ? topic.order : -1;
     prev = order - 1; next = order + 1;

--- a/views/misc/whereami.tt
+++ b/views/misc/whereami.tt
@@ -9,11 +9,12 @@ This program is free software; you may redistribute it and/or modify it under
 the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 %]
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 [%- sections.title = '.title' | ml -%]
 <p>[% '.intro' | ml %]</p>
 
 <form action='[% site.root %]/misc/whereami'>
     [% authas_html %]
-</form><br />
+</form>
 
 <p>[% '.cluster' | ml(user = u.ljuser_display, cluster = cluster_name) %]</p>

--- a/views/stats/site.tt
+++ b/views/stats/site.tt
@@ -13,7 +13,7 @@ This program is free software; you may redistribute it and/or modify it under
 the same terms as Perl itself. For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 %]
-
+[%- CALL dw.active_resource_group( "foundation" ) -%]
 [% dw.need_res( 'stc/sitestats.css' ) %]
 [% sections.title = '.title' | ml( sitenameshort => site.nameshort ) %]
 


### PR DESCRIPTION
CODE TOUR: We had moved some pages off BML, but not updated their HTML to use Foundation (or look good on mobile). This covers a bunch of those pages.

------
A bunch of these were basically just text pages that needed a little bit of CSS and HTML tweaks, but interests/index.tt got a little more rework as it was using tables.
Before:
![interests-old](https://github.com/user-attachments/assets/afd85473-9dca-49b0-a284-3f179086a52a)

After (desktop and mobile):
![interests-new](https://github.com/user-attachments/assets/2673a1f4-8205-427d-89c0-bdf7567db918)
![interests-new-mobile](https://github.com/user-attachments/assets/11abdb1c-499b-41d4-a961-7a36236bfe9a)
