### PR TITLE
Fix current-theme widget in gradation, and tweak font size

### DIFF
--- a/htdocs/stc/gradation/gradation.css
+++ b/htdocs/stc/gradation/gradation.css
@@ -959,6 +959,11 @@ div#cf-edit select {
     margin-bottom: -2em;
 }
 
+#canvas .appwidget-currenttheme .row {
+    margin: 0;
+    padding: 0;
+}
+
 /** Dark theme for color picker **/
 
 #clr-picker {

--- a/htdocs/stc/widgets/currenttheme.css
+++ b/htdocs/stc/widgets/currenttheme.css
@@ -47,7 +47,7 @@
     padding: 0 0 0 8px;
     margin-left: 0px;
     margin-bottom: 2px;
-    font-size: smaller;
+    font-size: small;
     background: url("/img/customize/arrow.gif") no-repeat 0 5px;
 }
 


### PR DESCRIPTION
CODE TOUR: When we converted the current theme widget to use Template Toolkit, we missed a CSS issue with Gradation that caused to display.... artistically on that site scheme. This also makes the link text on the widget slightly larger, as we got feedback that it was too small.

Fixes #3265