### PR TITLE
pin Crypt::SSLeay (required by Net::SSL) at version 0.58

### DIFF
--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -11,6 +11,7 @@ Class::Data::Inheritable
 Class::Trigger
 Compress::Zlib@2.212
 Convert::Base32
+Crypt::SSLeay@0.58
 CryptX
 Danga::Socket
 Data::ObjectDriver

--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -1,9 +1,9 @@
 Authen::OATH
-Authen::Passphrase::Clear
 Authen::Passphrase::BlowfishCrypt
+Authen::Passphrase::Clear
 Business::CreditCard
-CGI@4.50
 CGI::Cookie
+CGI@4.50
 Cache::Memcached
 Captcha::reCAPTCHA@0.99
 Class::Autouse


### PR DESCRIPTION
CODE TOUR: This attempts to require a specific version of a necessary third-party Perl code module.

The automatic base image build process has been failing for the past few days, apparently trying to compile Crypt::SSLeay version 0.66. @alierak says the last successful build used version 0.58. The module wasn't being requested explicitly, but it is a prerequisite for Net::SSL.

Hopefully just pinning the module will fix the problem. If not, we'll have to try something else.

This also does some minor cleanup, putting the entire list in correct sort order.