### PR TITLE
try removing Crypt::SSLeay and Net::SSL from cpanm list

### DIFF
--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -11,7 +11,6 @@ Class::Data::Inheritable
 Class::Trigger
 Compress::Zlib@2.212
 Convert::Base32
-Crypt::SSLeay@0.58
 CryptX
 Danga::Socket
 Data::ObjectDriver
@@ -48,7 +47,6 @@ Net::OAuth
 Net::OpenID::Consumer
 Net::OpenID::Server
 Net::SMTPS
-Net::SSL@2.85
 Net::Subnet
 Params::Classify@0.015
 Paws::S3


### PR DESCRIPTION
CODE TOUR: #3422 didn't work - trying something else

@alierak: "I'm not too sure any of it is needed now - we're getting LWP 6.77 (latest) which makes no reference to needing any dependency modules for https support. Also all this stuff including Crypt::SSLeay is already installed through apt by the time we get around to processing dependencies-cpanm."