### PR TITLE
Remove stray print line

### DIFF
--- a/cgi-bin/DW/Controller/Shop.pm
+++ b/cgi-bin/DW/Controller/Shop.pm
@@ -262,7 +262,6 @@ sub shop_cart_handler {
 
             foreach my $val ( keys %$POST ) {
                 next unless $POST->{$val} && $val =~ /^remove_(\d+)$/;
-                print $1;
                 $cart->remove_item($1);
             }
         }


### PR DESCRIPTION
CODE TOUR: Sometimes, devs add extra print statements to try and figure out why something is misbehaving. Sometimes, they forget to remove these once they've fixed the problem. This removes one such instance of this on the shop pages

Fixes  #3425