### PR TITLE
Fixes for customizing comms

### DIFF
--- a/htdocs/customize/options.bml
+++ b/htdocs/customize/options.bml
@@ -57,6 +57,11 @@ body<=
     $ret .= LJ::make_authas_select($remote, { authas => $GET{authas} });
     $ret .= "</form>";
 
+    if ($GET{authas}) {
+        $ret .= LJ::html_hidden(
+                { name => "authas", value => $GET{authas}, id => "_widget_authas" } );
+    }
+
     my $current_theme = LJ::Widget::CurrentTheme->new;
     $headextra .= $current_theme->wrapped_js( page_js_obj => "Customize" );
     $ret .= "<div class='theme-current pkg'>";

--- a/views/widget/journaltitles.tt
+++ b/views/widget/journaltitles.tt
@@ -12,7 +12,7 @@
         [% dw.form_auth() %]
         <p>
         [% IF u.is_community %]
-            <label>[% dw.ml("widget.journaltitles.$id.comm") %]</label>
+            <label>[% dw.ml("widget.journaltitles.${id}.comm") %]</label>
         [% ELSE %]
             <label>[% dw.ml("widget.journaltitles.$id") %]</label>
         [% END %]


### PR DESCRIPTION
CODE TOUR: Many months ago, we fixed an issue where trying to set styles and related options (like layout or titles) on comms made them apply to the user's regular journal instead. However, we missed that the issue was present on two pages, and only fixed one of them. This fixes the other page, and also fixes a much more minor issue where the labels for community journaltitles were missing in the customization UI.