### PR TITLE
[#3349] fix youtube profile links in user tags

### DIFF
--- a/cgi-bin/DW/External/Site/YouTube.pm
+++ b/cgi-bin/DW/External/Site/YouTube.pm
@@ -41,7 +41,7 @@ sub journal_url {
     croak 'need a DW::External::User'
         unless $u && ref $u eq 'DW::External::User';
 
-    return 'http://' . $self->{hostname} . '/user/' . $u->user;
+    return sprintf( "https://%s/@%s", $self->{hostname}, $u->user );
 }
 
 # argument: DW::External::User
@@ -51,7 +51,7 @@ sub profile_url {
     croak 'need a DW::External::User'
         unless $u && ref $u eq 'DW::External::User';
 
-    return 'http://' . $self->{hostname} . '/user/' . $u->user . "/about";
+    return sprintf( "https://%s/@%s/about", $self->{hostname}, $u->user );
 }
 
 # argument: DW::External::User
@@ -63,7 +63,7 @@ sub badge_image {
 
     # for lack of anything better, let's use the favicon
     return {
-        url    => "http://youtube.com/favicon.ico",
+        url    => "https://youtube.com/favicon.ico",
         width  => 16,
         height => 16,
     };


### PR DESCRIPTION
CODE TOUR: YouTube changed the format of their user links, without redirecting from the old to the new, so we needed to update our code to use the new format. This also changes the links to use https instead of http.

Fixes #3349.