### PR TITLE
[#3314] make Github icon show up on black background

### DIFF
--- a/cgi-bin/DW/External/Site/GitHub.pm
+++ b/cgi-bin/DW/External/Site/GitHub.pm
@@ -62,9 +62,10 @@ sub badge_image {
     croak 'need a DW::External::User'
         unless $u && ref $u eq 'DW::External::User';
 
-    # for lack of anything better, let's use the favicon
+    # we altered the favicon to show up on dark backgrounds
+    # original source: https://github.com/favicon.ico
     return {
-        url    => "https://github.com/favicon.ico",
+        url    => "$LJ::IMGPREFIX/profile_icons/github.png",
         width  => 16,
         height => 16,
     };


### PR DESCRIPTION
CODE TOUR: The default icon provided by Github is a transparent logo on a black background, which disappears when displayed on dark pages. A previous fix updated our local copy of the image to use white on black, which is visible on both light and dark backgrounds, for the profile page. This changes uses the same updated image with Github user tags.

Fixes #3314.