### PR TITLE
fix gettyimages embed URL pattern

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -78,7 +78,7 @@ my %host_path_match = (
     "www.flickr.com"     => [ qr!/player/$!, 1 ],
     "www.funnyordie.com" => [ qr!/embed/!,   1 ],
 
-    "embed.gettyimages.com" => [ qr!/iframe/!,                            1 ],
+    "embed.gettyimages.com" => [ qr!^/embed/!,                            1 ],
     "getyarn.io"            => [ qr!^/yarn-clip/embed/[0-9a-fA-F\-]{36}!, 1 ],
     "www.goodreads.com"     => [ qr!^/widgets/!,                          1 ],
     "giphy.com"             => [ qr!^/embed/\w+!,                         1 ],


### PR DESCRIPTION
CODE TOUR: correcting an error in the pattern for embed.gettyimages.com URLs that was causing a failing test