### PR TITLE
Error from compile test in poll conversion

### DIFF
--- a/cgi-bin/DW/Controller/Poll.pm
+++ b/cgi-bin/DW/Controller/Poll.pm
@@ -50,8 +50,6 @@ sub index_handler {
         return;
     }
 
-    my $remote = LJ::get_remote();
-
     my $pollid = ( $form->{'id'} || $form->{'pollid'} ) + 0;
 
     unless ($pollid) {


### PR DESCRIPTION
`"my" variable $remote masks earlier declaration in same scope ... cgi-bin/DW/Controller/Poll.pm line 53.`

This removes the duplicate assignment.

CODE TOUR: The code module for the converted poll code contained a duplicate variable assignment - the newer one from the controller and the older one from the original file. This removes the second, older assignment so that the compile test will pass cleanly.

<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
