### PR TITLE
Fix label for moderated comms on /manage/circle

### DIFF
--- a/views/manage/circle/edit/list.tt
+++ b/views/manage/circle/edit/list.tt
@@ -126,8 +126,9 @@
                 [% jointext = (status ? dw.ml(".circle.join.$status") : dw.ml('.circle.none')) %]
                 [% IF status == 'moderated' %]
                     [% jointext = jointext _ " " _
-                        dw.ml( '.circle.join.apply', { aopts => "href='$site.root/circle/$other_u{user}/edit'" } ) %]
+                        dw.ml( '.circle.join.apply', { aopts => "href='$site.root/circle/$other_u.user/edit'" } ) %]
                 [% END %]
+                [% joinvals.noescape = 1 %]
                 [% joinvals.selected = 0 %]
                 [% joinvals.disabled = u.can_leave( other_u ) ? 0 : 1 %]
             [% END %]


### PR DESCRIPTION
CODE TOUR: Fixes an issue where the URL to request membership in moderated comms was incorrect, and also fix TT escaping the link entirely