### PR TITLE
fix some issues with converted /manage/profile page

### DIFF
--- a/cgi-bin/DW/Controller/Manage/Profile.pm
+++ b/cgi-bin/DW/Controller/Manage/Profile.pm
@@ -255,7 +255,7 @@ sub profile_handler {
         }
 
         # bio
-        if ( length( $POST->{'bio'} ) >= LJ::BMAX_BIO ) {
+        if ( defined $POST->{'bio'} and length( $POST->{'bio'} ) >= LJ::BMAX_BIO ) {
             $errors->add( 'bio', "$scope.error.bio.toolong" );
         }
 
@@ -282,7 +282,8 @@ sub profile_handler {
         $newname = LJ::text_trim( $newname, LJ::BMAX_NAME, LJ::CMAX_NAME );
 
         my $newbio = defined( $POST->{'bio_absent'} ) ? $saved{'bio'} : $POST->{'bio'};
-        my $has_bio = ( $newbio =~ /\S/ ) ? "Y" : "N";
+        $newbio = "" unless defined $newbio;
+        my $has_bio   = ( $newbio =~ /\S/ ) ? "Y" : "N";
         my $new_bdate = sprintf( "%04d-%02d-%02d",
             $POST->{'year'}  || 0,
             $POST->{'month'} || 0,
@@ -344,7 +345,11 @@ sub profile_handler {
             if ( $POST->{'opt_sharebday'} =~ /^[AR]$/ ) {
 
                 # and actually provided a birthday
-                if ( $POST->{'month'} && $POST->{'month'} > 0 && $POST->{'day'} > 0 ) {
+                if (   $POST->{'month'}
+                    && $POST->{'month'} > 0
+                    && $POST->{'day'}
+                    && $POST->{'day'} > 0 )
+                {
 
                     # and allow the entire thing to be displayed
                     if ( $POST->{'opt_showbday'} eq "F" && $POST->{'year'} ) {

--- a/cgi-bin/DW/Controller/Manage/Profile.pm
+++ b/cgi-bin/DW/Controller/Manage/Profile.pm
@@ -179,6 +179,7 @@ sub profile_handler {
         u                => $u,
         authas_html      => $rv->{authas_html},
         formdata         => $POST,
+        iscomm           => $iscomm,
         curr_privacy     => $curr_privacy,
         opt_sharebday    => $opt_sharebday,
         text_in          => \&LJ::text_in,

--- a/cgi-bin/DW/Controller/Manage/Profile.pm
+++ b/cgi-bin/DW/Controller/Manage/Profile.pm
@@ -152,7 +152,8 @@ sub profile_handler {
     }
 
     my @months = map { $_, LJ::Lang::month_long_ml($_) } ( 1 .. 12 );
-    $u->{'opt_showbday'} = "D" unless $u->{'opt_showbday'} =~ m/^(D|F|N|Y)$/;
+    $u->{'opt_showbday'} = "D"
+        unless defined $u->{'opt_showbday'} and $u->{'opt_showbday'} =~ m/^(D|F|N|Y)$/;
     my $opt_sharebday = ( $u->opt_sharebday =~ m/^(A|F|N|R)$/ ) ? $u->opt_sharebday : 'F';
 
     # 'Other Services' display
@@ -169,7 +170,7 @@ sub profile_handler {
     # Email display
     # This is one prop in the backend, but two form fields on the settings page
     # so we need to do some jumping around to get the correct values for both fields
-    my $checked = ( $u->{'opt_whatemailshow'} =~ /[BVL]/ ) ? 'Y' : 'N';
+    my $checked = ( ( $u->{'opt_whatemailshow'} // '' ) =~ /[BVL]/ ) ? 'Y' : 'N';
     my $cur     = $u->opt_whatemailshow;
 
     # drop BVL values that govern site alias; we input that below instead

--- a/cgi-bin/DW/Controller/Manage/Profile.pm
+++ b/cgi-bin/DW/Controller/Manage/Profile.pm
@@ -151,7 +151,9 @@ sub profile_handler {
         if ( $bdpart{'day'} eq "00" )    { $bdpart{'day'}  = ""; }
     }
 
-    my @months = map { $_, LJ::Lang::month_long_ml($_) } ( 1 .. 12 );
+    my @months = ( 0, "" );
+    push @months, map { $_, LJ::Lang::month_long_ml($_) } ( 1 .. 12 );
+
     $u->{'opt_showbday'} = "D"
         unless defined $u->{'opt_showbday'} and $u->{'opt_showbday'} =~ m/^(D|F|N|Y)$/;
     my $opt_sharebday = ( $u->opt_sharebday =~ m/^(A|F|N|R)$/ ) ? $u->opt_sharebday : 'F';

--- a/views/manage/profile.tt
+++ b/views/manage/profile.tt
@@ -98,7 +98,7 @@
             <td class='field_name' role="cell">[% dw.ml('.fn.birthday') %]</td>
             <td class='bday_field' role="cell">
                 [%- form.select( name => 'month', title => dw.ml('.fn.birthday.month'),
-                                 selected => int( bdpart.month ),
+                                 selected => ( bdpart.month + 0 ),
                                 items => month_select,
                                 class => 'inline'
                                  ) -%]


### PR DESCRIPTION
CODE TOUR: When using the new version of the Manage Profile page, I managed to accidentally change my birth month to January, because the previously saved value wasn't being loaded into the form correctly. This fixes that issue plus a couple of others I uncovered during testing.

Fixes #3440.