### PR TITLE
new profile services don't have legacy userprops

### DIFF
--- a/bin/upgrading/base-data.sql
+++ b/bin/upgrading/base-data.sql
@@ -393,9 +393,9 @@ INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_form
 UPDATE profile_services SET userprop='twitter', imgfile='twitter_bird.png', title_ml='profile.service.twitter', url_format='//www.twitter.com/%s', maxlen=40 WHERE name='twitter';
 INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_format, maxlen) VALUES ('wattpad', 'wattpad', 'wattpad.png', 'profile.service.wattpad', '//www.wattpad.com/user/%s', 20);
 UPDATE profile_services SET userprop='wattpad', imgfile='wattpad.png', title_ml='profile.service.wattpad', url_format='//www.wattpad.com/user/%s', maxlen=20 WHERE name='wattpad';
-INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_format, maxlen) VALUES ('steam', 'steam', 'steam.png', 'profile.service.steam', '//steamcommunity.com/id/%s/', 32);
-UPDATE profile_services SET userprop='steam', imgfile='steam.png', title_ml='profile.service.steam', url_format='//steamcommunity.com/id/%s/', maxlen=32 WHERE name='steam';
-INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_format, maxlen) VALUES ('spotify', 'spotify', 'spotify.png', 'profile.service.spotify', '//open.spotify.com/user/%s', 32);
-UPDATE profile_services SET userprop='spotify', imgfile='spotify.png', title_ml='profile.service.spotify', url_format='//open.spotify.com/user/%s', maxlen=32 WHERE name='spotify';
-INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_format, maxlen) VALUES ('squidgeworld', 'squidgeworld', 'squidgeworld.png', 'profile.service.squidgeworld', '//squidgeworld.org/users/%s', 40);
-UPDATE profile_services SET userprop='squidgeworld', imgfile='squidgeworld.png', title_ml='profile.service.squidgeworld', url_format='//squidgeworld.org/users/%s', maxlen=40 WHERE name='squidgeworld';
+INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_format, maxlen) VALUES ('steam', NULL, 'steam.png', 'profile.service.steam', '//steamcommunity.com/id/%s/', 32);
+UPDATE profile_services SET userprop=NULL, imgfile='steam.png', title_ml='profile.service.steam', url_format='//steamcommunity.com/id/%s/', maxlen=32 WHERE name='steam';
+INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_format, maxlen) VALUES ('spotify', NULL, 'spotify.png', 'profile.service.spotify', '//open.spotify.com/user/%s', 32);
+UPDATE profile_services SET userprop=NULL, imgfile='spotify.png', title_ml='profile.service.spotify', url_format='//open.spotify.com/user/%s', maxlen=32 WHERE name='spotify';
+INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_format, maxlen) VALUES ('squidgeworld', NULL, 'squidgeworld.png', 'profile.service.squidgeworld', '//squidgeworld.org/users/%s', 40);
+UPDATE profile_services SET userprop=NULL, imgfile='squidgeworld.png', title_ml='profile.service.squidgeworld', url_format='//squidgeworld.org/users/%s', maxlen=40 WHERE name='squidgeworld';

--- a/cgi-bin/DW/Logic/ProfilePage.pm
+++ b/cgi-bin/DW/Logic/ProfilePage.pm
@@ -810,6 +810,7 @@ sub external_services {
     $u->preload_props(@$userprops);
 
     foreach my $site (@$services) {
+        next unless defined $site->{userprop};
         if ( my $acct = $u->prop( $site->{userprop} ) ) {
             push @ret, $info->( $acct, $site );
         }


### PR DESCRIPTION
The new profile services included `userprop` db values even though those were only intended for legacy values, and those userprops didn't actually ever exist. Fixing that uncovered a bug where services without a legacy userprop weren't being skipped when trying to display the nonexistent legacy values in the user profile, so the entire page died with a database error.

CODE TOUR: new services (steam, spotify, squidgeworld) were causing the profile page to die with a database error; this should fix it.