### PR TITLE
use the gift_url user method

### DIFF
--- a/views/widget/friendbirthdays.tt
+++ b/views/widget/friendbirthdays.tt
@@ -13,7 +13,7 @@
         { 'month' => month_short(month), 'day' => day } ) %]
     </li>
     <li>[% u.ljuser_display %]</li>
-    <li><a href='[% u.gift_link %]' class='gift-link'>
+    <li><a href='[% u.gift_url %]' class='gift-link'>
         [% dw.ml('widget.friendbirthdays.gift') %]</a>
     </li>
   </ul>


### PR DESCRIPTION
CODE TOUR: this adjusts the birthday widget on the homepage to use the correct method name for the gift links.

Fixes #3452.