### PR TITLE
Keep '/poll/' from redirecting to '/poll', which breaks form post

### DIFF
--- a/cgi-bin/DW/Controller/Poll.pm
+++ b/cgi-bin/DW/Controller/Poll.pm
@@ -25,7 +25,8 @@ use DW::Template;
 use DW::FormErrors;
 use LJ::Poll;
 
-DW::Routing->register_string( '/poll',        \&index_handler,  app => 1 );
+DW::Routing->register_string( '/poll',  \&index_handler, app => 1, no_redirects => 1 );
+DW::Routing->register_string( '/poll/', \&index_handler, app => 1, no_redirects => 1 );
 DW::Routing->register_string( '/poll/create', \&create_handler, app => 1 );
 
 sub index_handler {


### PR DESCRIPTION
CODE TOUR: We have code that makes it so if a user navigates to `dreamwidth.org/somewhere/` , it will redirect them to the 'official' address of `dreamwidth.org/somewhere`. And mostly this works fine, but it *doesn't* work when trying to send a form response to the server, because the 'official' address endpoint never actually sees the data. This resulted in polls failing to work when not submitted via Javascript from within a journal entry, and has now been fixed.