### PR TITLE
[#3358] don't show checkout buttons when viewing receipt

### DIFF
--- a/cgi-bin/LJ/Widget/ShopCart.pm
+++ b/cgi-bin/LJ/Widget/ShopCart.pm
@@ -93,7 +93,7 @@ sub render_body {
     $vars->{is_random} = sub { return ref $_ =~ /Account/ && $_->random ? 'Y' : 'N'; };
 
     my $checkout_ready =
-        !$opts{receipt} || ( !$opts{confirm} && $cart->state == $DW::Shop::STATE_CHECKOUT );
+        !$receipt || ( !$opts{confirm} && $cart->state == $DW::Shop::STATE_CHECKOUT );
     if ($checkout_ready) {
 
         # check or money order button


### PR DESCRIPTION
Can't test this without payment history, but reading through the surrounding block of code, I believe changing `$opts{receipt}` to `$receipt` is the correct fix here, given that the latter is forced to be true when viewing the page as an admin.

CODE TOUR: In the admin pages, don't show the cart checkout buttons when viewing the payment receipt.

Fixes #3358.
