### PR TITLE
[#3433] don't use method call on undefined rename token

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2409,6 +2409,8 @@ rename.error.isself=Cannot rename back to your own username.
 
 rename.error.noto=No username provided to rename to.
 
+rename.error.notoken=Rename token not provided or unavailable.
+
 rename.error.reserved="[[to]]" is a reserved username.
 
 rename.error.tokenapplied=This token has already been used.

--- a/cgi-bin/DW/Controller/Rename.pm
+++ b/cgi-bin/DW/Controller/Rename.pm
@@ -345,6 +345,7 @@ sub rename_admin_edit_handler {
     my $get_args  = $r->get_args;
 
     my $token = DW::RenameToken->new( token => $get_args->{token} );
+    return error_ml('rename.error.notoken') unless defined $token;
 
     my $u         = LJ::load_userid( $token->renuserid );
     my @rel_types = qw( trusted_by watched_by trusted watched communities );


### PR DESCRIPTION
CODE TOUR: This stops one of the admin pages from dying with a Perl error if a valid rename token wasn't provided.

Fixes #3433.