### PR TITLE
[#3463] load jquery.poll.js on poll/index

### DIFF
--- a/views/poll/index.tt
+++ b/views/poll/index.tt
@@ -1,6 +1,8 @@
 [%- sections.title = '.title' | ml -%]
 [%- CALL dw.active_resource_group( "foundation" ) -%]
 
+[%- dw.need_res( { group => "foundation" }, "js/jquery.poll.js" ) -%]
+
 [%- FOREACH m IN [[ "enter", dw.ml('.filloutpoll') ], [ "results" , dw.ml('.viewresults') ]] -%]
     [%- NEXT IF m.0 == "enter" && poll.is_closed -%]
     [%- IF mode == m.0 -%]


### PR DESCRIPTION
This is needed for the "ans_extended" mode to work.

Fixes #3463.

CODE TOUR: another fix for something that didn't work as expected after converting the poll page.