### PR TITLE
fix non-JS version of ans_extended mode for poll page

### DIFF
--- a/cgi-bin/LJ/Poll.pm
+++ b/cgi-bin/LJ/Poll.pm
@@ -923,7 +923,7 @@ sub render {
 
         my @userids;
 
-        my $respondents = $self->journal->selectall_arrayref(
+        my $respondents = $self->journal->selectcol_arrayref(
             "SELECT DISTINCT(userid) FROM pollresult2 WHERE pollid=? AND journalid=? ",
             undef, $pollid, $self->journalid );
 


### PR DESCRIPTION
Found a bug in some code from 2011 that was using the wrong DBI method name.

CODE TOUR: fix this page for non-JS mode, too.
