### PR TITLE
fix rename link in shop

### DIFF
--- a/views/shop/renames.tt
+++ b/views/shop/renames.tt
@@ -15,7 +15,7 @@
 [% cart_display %]
 
 <p>[% dw.ml( ".intro.$for" ) %]</p>
-<p>[% dw.ml( '.action', { aopts => "href='/rename'" } )  %]</p>
+<p>[% dw.ml( '.action', { aopts => "href='${site.root}/rename'" } )  %]</p>
 
 <div style='clear: both;'></div>
 <form method='post'>


### PR DESCRIPTION
CODE TOUR: Update another link that needed to be fixed to point to the main www site after moving the shop to its own domain.