### PR TITLE
clarify who can buy premium time for paid accounts

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -5417,6 +5417,8 @@ widget.shopitemoptions.error.notforsale=This purchase type is currently not for 
 
 widget.shopitemoptions.error.notloggedin=You must be logged in as a personal account in order to purchase paid time for yourself.
 
+widget.shopitemoptions.error.notype=Please select which type of account time you wish to purchase.
+
 widget.shopitemoptions.error.nousers=There are currently no active free users.
 
 widget.shopitemoptions.header.paid=Paid Account

--- a/cgi-bin/DW/Controller/Shop/Account.pm
+++ b/cgi-bin/DW/Controller/Shop/Account.pm
@@ -137,6 +137,10 @@ sub shop_account_handler {
             DW::Pay::validate_deliverydate( $post->{deliverydate}, $errors, $item_data );
         }
 
+        unless ( $post->{accttype} ) {
+            $errors->add( 'accttype', 'widget.shopitemoptions.error.notype' );
+        }
+
         unless ( $errors->exist ) {
             $item_data->{anonymous} = 1
                 if $post->{anonymous} || !$remote;

--- a/cgi-bin/DW/Controller/Shop/Account.pm
+++ b/cgi-bin/DW/Controller/Shop/Account.pm
@@ -188,7 +188,7 @@ sub shop_account_handler {
                             { date => $exptime->ymd, premium_num => $prem_d, paid_num => $paid_d };
 
                         # but only include date if the logged-in user owns the account
-                        delete $ml_args->{date} unless $remote && $remote->has_same_email_as($u);
+                        delete $ml_args->{date} unless $remote && $remote->can_purchase_for($u);
 
                         $errors->add( undef, '/shop/account.tt.error.premiumconvert', $ml_args );
                         $errors->add( undef, '/shop/account.tt.error.premiumconvert.postdate',

--- a/cgi-bin/DW/Shop/Item/Account.pm
+++ b/cgi-bin/DW/Shop/Item/Account.pm
@@ -420,7 +420,7 @@ sub allow_account_conversion {
 
     # allow upgrading to premium if the remote user owns this account
     my $remote = LJ::get_remote();
-    return 1 if $to eq 'premium' && $remote && $remote->has_same_email_as($u);
+    return 1 if $to eq 'premium' && $remote && $remote->can_purchase_for($u);
 
     return 0;
 }

--- a/cgi-bin/LJ/User/Journal.pm
+++ b/cgi-bin/LJ/User/Journal.pm
@@ -100,6 +100,23 @@ sub can_post_to {
     return 0;
 }
 
+sub can_purchase_for {
+    my ( $remote, $u ) = @_;
+    croak "Invalid users passed to LJ::User->can_purchase_for."
+        unless LJ::isu($u) && LJ::isu($remote);
+
+    # if it's a community, allow if admin
+    return 1 if $u->is_community && $remote->can_manage($u);
+
+    # otherwise, you have to be acting on an individual
+    return 0 unless $u->is_individual;
+
+    # allow if both accounts are registered to the same address
+    return 1 if $remote->has_same_email_as($u);
+
+    return 0;
+}
+
 # list of communities that $u manages
 sub communities_managed_list {
     my ($u) = @_;


### PR DESCRIPTION
CODE TOUR: if a community admin wants to upgrade their paid community to premium paid, they should be allowed to do so.

This also detects an issue with forgetting to choose an account type before submitting the form, which would attempt to print a blank error message.

Fixes #3355.