### PR TITLE
only skip active sticky entries when rendering RecentPage

### DIFF
--- a/cgi-bin/LJ/S2/RecentPage.pm
+++ b/cgi-bin/LJ/S2/RecentPage.pm
@@ -223,7 +223,7 @@ sub RecentPage {
 
     $opts->{cut_disable} = ( $remote && $remote->prop('opt_cut_disable_journal') );
 
-    my $sticky_entries = $u->sticky_entries_lookup;
+    my $sticky_entries = { map { $_ => 1 } $u->sticky_entry_active_ids };
 
 ENTRY:
     foreach my $item (@items) {

--- a/cgi-bin/LJ/User/Permissions.pm
+++ b/cgi-bin/LJ/User/Permissions.pm
@@ -1411,11 +1411,21 @@ sub sticky_entries {
     return @entries;
 }
 
-# returns a list of sticky entry ids
+# returns a list of all sticky entry ids
 sub sticky_entry_ids {
     my $prop = $_[0]->prop('sticky_entry');
     return unless defined $prop;
     return split /,/, $prop;
+}
+
+# returns a list of active sticky entry ids
+sub sticky_entry_active_ids {
+    my ($u) = @_;
+    my $max = $u->count_max_stickies || 0;
+    my @ids = $u->sticky_entry_ids;
+    return unless @ids;
+    @ids = @ids[ 0 .. $max - 1 ] if scalar @ids > $max;
+    return @ids;
 }
 
 # returns a map of ditemid => 1 of the sticky entries


### PR DESCRIPTION
I haven't tested this apart from making sure things compile, but this should ensure that inactive sticky entries don't get skipped when they should instead be rendered as normal entries.

CODE TOUR: if a journal's paid time expired and had more sticky entries than currently allowed, the additional sticky entries wouldn't show at all in the journal.

Fixes #2691.