### PR TITLE
block crawlers from indexing /support/help and /support/see_request

### DIFF
--- a/cgi-bin/DW/Controller/Support/Request.pm
+++ b/cgi-bin/DW/Controller/Support/Request.pm
@@ -98,6 +98,8 @@ sub see_request_handler {
 
     return error_ml("$scope.unknownumber") unless $sp;
 
+    $vars->{robot_meta_tags} = LJ::robot_meta_tags();
+
     my $sth;
     my $user;
     my $user_url;

--- a/htdocs/support/help.bml
+++ b/htdocs/support/help.bml
@@ -14,6 +14,8 @@
 _c?>
 <?page
 head<=
+<?_code return LJ::robot_meta_tags(); _code?>
+
 <style type='text/css'>
 .green, .green td {
     background-color: #d0eed0;

--- a/views/support/see_request.tt
+++ b/views/support/see_request.tt
@@ -15,6 +15,10 @@ reference 'perldoc perlartistic' or 'perldoc perlgpl'.
 %]
 
 [%- sections.title = '.title' | ml( reqid = spid) -%]
+[%- sections.head = BLOCK %]
+  [% robot_meta_tags %]
+[% END %]
+
 [%- CALL dw.active_resource_group("foundation") -%]
 
 [%- dw.need_res({ group => "foundation"},


### PR DESCRIPTION
CODE TOUR: don't include details of support requests in search engines.

Fixes #3323.