### PR TITLE
update all nonfree files to use nonfree licensing boilerplate text

### DIFF
--- a/ext/dw-nonfree/schemes/_dreamwidth.tt
+++ b/ext/dw-nonfree/schemes/_dreamwidth.tt
@@ -10,9 +10,10 @@ Common code for Dreamwidth site schemes
 
 Copyright (c) 2010-2011 by Dreamwidth Studios, LLC.
 
-This program is free software; you may redistribute it and/or modify it under
-the same terms as Perl itself.  For a copy of the license, please reference
-'perldoc perlartistic' or 'perldoc perlgpl'.
+This program is NOT free software or open-source; you can use it as an
+example of how to implement your own site-specific extensions to the
+Dreamwidth Studios open-source code, but you cannot use it on your site
+or redistribute it, with or without modifications.
 
 %][%- BLOCK block.logo -%]
 [%- IF ! logo_path %]

--- a/ext/dw-nonfree/schemes/celerity-local.tt
+++ b/ext/dw-nonfree/schemes/celerity-local.tt
@@ -5,8 +5,9 @@ Authors:
 
 Copyright (c) 2015 by Dreamwidth Studios, LLC.
 
-This program is free software; you may redistribute it and/or modify it under
-the same terms as Perl itself.  For a copy of the license, please reference
-'perldoc perlartistic' or 'perldoc perlgpl'.
+This program is NOT free software or open-source; you can use it as an
+example of how to implement your own site-specific extensions to the
+Dreamwidth Studios open-source code, but you cannot use it on your site
+or redistribute it, with or without modifications.
 %]
 [%- PROCESS '_dreamwidth.tt' logo_path_part='celerity' -%]

--- a/ext/dw-nonfree/schemes/gradation-horizontal-local.tt
+++ b/ext/dw-nonfree/schemes/gradation-horizontal-local.tt
@@ -5,8 +5,9 @@ Authors:
 
 Copyright (c) 2015 by Dreamwidth Studios, LLC.
 
-This program is free software; you may redistribute it and/or modify it under
-the same terms as Perl itself.  For a copy of the license, please reference
-'perldoc perlartistic' or 'perldoc perlgpl'.
+This program is NOT free software or open-source; you can use it as an
+example of how to implement your own site-specific extensions to the
+Dreamwidth Studios open-source code, but you cannot use it on your site
+or redistribute it, with or without modifications.
 %]
 [%- PROCESS '_dreamwidth.tt' logo_path_part='gradation' -%]

--- a/ext/dw-nonfree/schemes/gradation-vertical-local.tt
+++ b/ext/dw-nonfree/schemes/gradation-vertical-local.tt
@@ -5,8 +5,9 @@ Authors:
 
 Copyright (c) 2015 by Dreamwidth Studios, LLC.
 
-This program is free software; you may redistribute it and/or modify it under
-the same terms as Perl itself.  For a copy of the license, please reference
-'perldoc perlartistic' or 'perldoc perlgpl'.
+This program is NOT free software or open-source; you can use it as an
+example of how to implement your own site-specific extensions to the
+Dreamwidth Studios open-source code, but you cannot use it on your site
+or redistribute it, with or without modifications.
 %]
 [%- PROCESS '_dreamwidth.tt' logo_path_part='gradation' -%]

--- a/ext/dw-nonfree/schemes/tropo-common.tt
+++ b/ext/dw-nonfree/schemes/tropo-common.tt
@@ -12,9 +12,10 @@ Common code for Tropospherical site schemes, refactored for inheritance.
 
 Copyright (c) 2010-2013 by Dreamwidth Studios, LLC.
 
-This program is free software; you may redistribute it and/or modify it under
-the same terms as Perl itself.  For a copy of the license, please reference
-'perldoc perlartistic' or 'perldoc perlgpl'.
+This program is NOT free software or open-source; you can use it as an
+example of how to implement your own site-specific extensions to the
+Dreamwidth Studios open-source code, but you cannot use it on your site
+or redistribute it, with or without modifications.
 
 %][%- PROCESS '_dreamwidth.tt' -%]
 

--- a/ext/dw-nonfree/schemes/tropo-purple.tt
+++ b/ext/dw-nonfree/schemes/tropo-purple.tt
@@ -10,8 +10,9 @@ Tropospherical Site Scheme
 
 Copyright (c) 2010-2011 by Dreamwidth Studios, LLC.
 
-This program is free software; you may redistribute it and/or modify it under
-the same terms as Perl itself.  For a copy of the license, please reference
-'perldoc perlartistic' or 'perldoc perlgpl'.
+This program is NOT free software or open-source; you can use it as an
+example of how to implement your own site-specific extensions to the
+Dreamwidth Studios open-source code, but you cannot use it on your site
+or redistribute it, with or without modifications.
 
 %][%- tropo_color = 'purple' -%]

--- a/ext/dw-nonfree/schemes/tropo-red.tt
+++ b/ext/dw-nonfree/schemes/tropo-red.tt
@@ -10,8 +10,9 @@ Tropospherical Site Scheme
 
 Copyright (c) 2010-2011 by Dreamwidth Studios, LLC.
 
-This program is free software; you may redistribute it and/or modify it under
-the same terms as Perl itself.  For a copy of the license, please reference
-'perldoc perlartistic' or 'perldoc perlgpl'.
+This program is NOT free software or open-source; you can use it as an
+example of how to implement your own site-specific extensions to the
+Dreamwidth Studios open-source code, but you cannot use it on your site
+or redistribute it, with or without modifications.
 
 %][%- tropo_color = 'red' -%]

--- a/ext/dw-nonfree/views/error/404.tt
+++ b/ext/dw-nonfree/views/error/404.tt
@@ -6,9 +6,10 @@ Authors:
 
 Copyright (c) 2015 by Dreamwidth Studios, LLC.
 
-This program is free software; you may redistribute it and/or modify it under
-the same terms as Perl itself.  For a copy of the license, please reference
-'perldoc perlartistic' or 'perldoc perlgpl'.
+This program is NOT free software or open-source; you can use it as an
+example of how to implement your own site-specific extensions to the
+Dreamwidth Studios open-source code, but you cannot use it on your site
+or redistribute it, with or without modifications.
 %]
 
 [%- sections.windowtitle = "Page not found" -%]

--- a/ext/dw-nonfree/views/legal/dmca.tt
+++ b/ext/dw-nonfree/views/legal/dmca.tt
@@ -7,9 +7,10 @@
   #
   # Copyright (c) 2009 by Dreamwidth Studios, LLC.
   #
-  # This program is free software; you may redistribute it and/or modify it
-  # or redistribute it, with or without modifications, subject to the 
-  # license terms stated in the text.
+  # This program is NOT free software or open-source; you can use it as an
+  # example of how to implement your own site-specific extensions to the
+  # Dreamwidth Studios open-source code, but you cannot use it on your site
+  # or redistribute it, with or without modifications.
   #
 %]
 

--- a/ext/dw-nonfree/views/misc/about.tt
+++ b/ext/dw-nonfree/views/misc/about.tt
@@ -5,9 +5,11 @@ Authors:
 
 Copyright (c) 2015 by Dreamwidth Studios, LLC.
 
-This program is free software; you may redistribute it and/or modify it under
-the same terms as Perl itself.  For a copy of the license, please reference
-'perldoc perlartistic' or 'perldoc perlgpl'.
+This program is NOT free software or open-source; you can use it as an
+example of how to implement your own site-specific extensions to the
+Dreamwidth Studios open-source code, but you cannot use it on your site
+or redistribute it, with or without modifications.
+
 %]
 [%- sections.title='About Dreamwidth Studios' -%]
 


### PR DESCRIPTION
CODE TOUR: no user-facing changes

Some of the files in the nonfree subdirectory had copied over the `This program is free software; you may redistribute it and/or modify it...` boilerplate from elsewhere in the project, instead of `This program is NOT free software or open-source; you can use it as an example...` as intended. The ext/dw-nonfree/LICENSE file should be considered the definitive statement on the subject, but keeping the boilerplate text consistent will reduce confusion.